### PR TITLE
Fixed generate-imposm3 mapping - process tags - required for relations.

### DIFF
--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -10,6 +10,7 @@ def create_imposm3_mapping(tileset_filename):
 
     generalized_tables = {}
     tables = {}
+    tags = {}
 
     for layer in tileset.layers:
         for mapping in layer.imposm_mappings:
@@ -17,8 +18,11 @@ def create_imposm3_mapping(tileset_filename):
                 generalized_tables[table_name] = definition
             for table_name, definition in mapping.get('tables', {}).items():
                 tables[table_name] = definition
+            for tag_name, definition in mapping.get('tags', {}).items():
+                tags[tag_name] = definition
 
     return {
+        'tags': tags,
         'generalized_tables': generalized_tables,
         'tables': tables,
     }


### PR DESCRIPTION
Importing relations from OSM data requires `tags: {load_all: true}` in the `mapping.yaml` file.

When this tag was typed in the separate mapping file, using the utility `generate-imposm3` failed to append this statement.
Therefore, importing relations from OSM wasn't working.