### PR TITLE
Add ZRes support to Openmaptiles-tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Test dirs
+testbuild/
+testlayers/

--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -3,6 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 
 from .tileset import Tileset
 
+import sys
+import re
+
+def ZRes(z):
+    return 40075016.6855785/(256*2**z) # See https://github.com/mapbox/postgis-vt-util/blob/master/src/ZRes.sql
 
 def create_imposm3_mapping(tileset_filename):
     tileset = Tileset.parse(tileset_filename)
@@ -15,6 +20,11 @@ def create_imposm3_mapping(tileset_filename):
     for layer in tileset.layers:
         for mapping in layer.imposm_mappings:
             for table_name, definition in mapping.get('generalized_tables', {}).items():
+                if 'tolerance' in definition:
+                    if re.match(r"^Z\d{1,2}$", definition['tolerance']):
+                        definition['tolerance'] = ZRes(float(definition['tolerance'][1:3]))
+                    else:
+                        raise SyntaxError('Unrecognized tolerance '+str(definition['tolerance']))
                 generalized_tables[table_name] = definition
             for table_name, definition in mapping.get('tables', {}).items():
                 tables[table_name] = definition

--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -21,11 +21,14 @@ def create_imposm3_mapping(tileset_filename):
         for mapping in layer.imposm_mappings:
             for table_name, definition in mapping.get('generalized_tables', {}).items():
                 if 'tolerance' in definition:
-                    if re.match(r"^Z\d{1,2}$", definition['tolerance']):
-                        definition['tolerance'] = ZRes(float(definition['tolerance'][1:3]))
-                    else:
-                        raise SyntaxError('Unrecognized tolerance '+str(definition['tolerance']))
-                generalized_tables[table_name] = definition
+                    try:
+                        generalized_tables[table_name] = float(definition['tolerance'])
+                    except:
+                        if re.match(r"^Z\d{1,2}$", definition['tolerance']):
+                            definition['tolerance'] = ZRes(float(definition['tolerance'][1:3]))
+                            generalized_tables[table_name] = definition
+                        else:
+                            raise SyntaxError('Unrecognized tolerance '+str(definition['tolerance']))
             for table_name, definition in mapping.get('tables', {}).items():
                 tables[table_name] = definition
             for tag_name, definition in mapping.get('tags', {}).items():


### PR DESCRIPTION
This pull adds support for Z## in the tolerance field, which is then turned into a real value and put into the final tile schema. 
Has some error checking for bad values.
Needs a final test of functionality.