### PR TITLE
Fixing poor conflict resolution on the previous merge

### DIFF
--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -3,6 +3,11 @@ from __future__ import (absolute_import, division, print_function,
 
 from .tileset import Tileset
 
+import sys
+import re
+
+def ZRes(z):
+    return 40075016.6855785/(256*2**z) # See https://github.com/mapbox/postgis-vt-util/blob/master/src/ZRes.sql
 
 def create_imposm3_mapping(tileset_filename):
     tileset = Tileset.parse(tileset_filename)


### PR DESCRIPTION
Sorry for the noise on adding this feature.

The previous merge (and the conflict resolve) missed some lines. Since the travis tests don't use the ZRes feature, the issue was completely missed until later manual testing.