### PR TITLE
Fix for Generated Metadata for bounds and centered always compute to zero (`0`)

### DIFF
--- a/bin/generate-metadata
+++ b/bin/generate-metadata
@@ -3,6 +3,7 @@
 
 Usage:
   generate_metadata <mbtiles>
+  generate_metadata <mbtiles> <west> <south> <east> <north>
   generate_metadata (-h | --help)
   generate_metadata --version
 
@@ -14,7 +15,8 @@ Options:
 # generate_metadata ./data/tiles.mbtiles
 
 # TODO:  better BBOX parameters ..
-# TODO:  test! 
+  # TODO:  parse os.environ.get('BBOX') for west, south, east, values
+# TODO:  test!
 
 from __future__ import print_function
 
@@ -38,10 +40,10 @@ class Extract(object):
         self.country = country
         self.city = city
 
-        self.min_lon = left
-        self.min_lat = bottom
-        self.max_lon = right
-        self.max_lat = top
+        self.min_lon = float(left)
+        self.min_lat = float(bottom)
+        self.max_lon = float(right)
+        self.max_lat = float(top)
 
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
@@ -91,18 +93,24 @@ def update_metadata(mbtiles_file, metadata):
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
+    print (args)
 
     extract_file= args['<mbtiles>']
+
+    left = args['<west>']
+    bottom = args['<south>']
+    right = args['<east>']
+    top = args['<north>']
 
     extract = Extract(extract_file,
                         country=None,
                         city=None,
-                        left=-180,
-                        right=180,
-                        top=85.0511,
-                        bottom=-85.0511,
+                        left=left,
+                        right=right,
+                        top=top,
+                        bottom=bottom,
                         center_zoom=2,
-                        min_zoom= os.environ.get('QUICKSTART_MIN_ZOOM', 0), 
+                        min_zoom= os.environ.get('QUICKSTART_MIN_ZOOM', 0),
                         max_zoom= os.environ.get('QUICKSTART_MAX_ZOOM', 14),
                         )
 

--- a/bin/generate-metadata
+++ b/bin/generate-metadata
@@ -92,7 +92,7 @@ def update_metadata(mbtiles_file, metadata):
     conn.close()
 
 if __name__ == '__main__':
-    args = docopt(__doc__, version=openmaptiles.__version__)
+    args = docopt(__doc__, version=openmaptiles.__version__, options_first=True)
     print (args)
 
     extract_file= args['<mbtiles>']

--- a/openmaptiles/tmsource.py
+++ b/openmaptiles/tmsource.py
@@ -18,6 +18,7 @@ def generate_tm2source(tileset_filename, db_params):
     tm2 = {
         'attribution': tileset['attribution'],
         'center': tileset['center'],
+        'bounds': tileset['bounds'],
         'description': tileset['description'],
         'maxzoom': tileset['maxzoom'],
         'minzoom': tileset['minzoom'],


### PR DESCRIPTION
`generate-metadata` is required when generating mbtiles for use with `tileserver-gl`.  It generates a valid `version`, `attribution` and others, but it does not properly compute the center.  `tileserver-gl` relies on the center to give a proper starting point and to generate valid thumbnails 

This approach uses `docopt` to pass in a bounding box.  

TODO — parse os.environ.get('BBOX') for west, south, east, north, values

---

#### Current defaults, average computes to zero 
https://github.com/openmaptiles/openmaptiles-tools/blob/37c9e052a9de40476f68252e6bd13185e2c2462e/bin/generate-metadata#L100-L103

----

### Example with this PR

![generate-metadata](https://user-images.githubusercontent.com/118112/31469497-aa7f549e-ae96-11e7-8698-db5a533eb46f.png)

