### PR TITLE
Install docker-compose as part of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.6
 
 RUN apt-get update \ 
     && apt-get install  -y --no-install-recommends \
+        docker-compose \
         graphviz \
         sqlite3 \
     && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Implements https://github.com/openmaptiles/openmaptiles/issues/583

This patch allows any make command via a docker, without any extra packages on the host:
```
docker run \
  -v $(pwd):/tileset \
  -v /var/run/docker.sock:/var/run/docker.sock \
  openmaptiles/openmaptiles-tools \
  make refresh-docker-images
```