### PR TITLE
Make travis report errors (duh!), update checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 script:
+  - set -e
   - sudo service docker restart
   - docker-compose -v
   - docker info

--- a/checklist.chk
+++ b/checklist.chk
@@ -1,5 +1,5 @@
-e3d2790848640df1c3dd81b5ae477f00  ./testbuild/testmaptiles.tm2source/data.yml
-79e19f1e20afa5c2e8c7a705b95119ee  ./testbuild/mapping.yaml
+181fa05eb18eeae787bf8fd9fc19da61  ./testbuild/testmaptiles.tm2source/data.yml
+a9923eeaa91b045373b9932c8185e668  ./testbuild/mapping.yaml
 48880261e757a91bd424244d98f2506d  ./testbuild/tileset.sql
 2bbb5f07cf224ce595b7e6863bbbeac4  ./testbuild/doc/housenumber.md
 1023bb8893f5bd1077a0376d5c0c4e5d  ./testbuild/sqlquery.sql


### PR DESCRIPTION
Updating travis, updating checksums (i have no idea if these are correct)

Turns out Travis hasn't been reporting errors...
See https://github.com/travis-ci/travis-ci/issues/1066

Since I don't know when, it has been reporting this. See [example](https://travis-ci.org/openmaptiles/openmaptiles-tools/jobs/508725013):
```
md5sum -c checklist.chk
./testbuild/testmaptiles.tm2source/data.yml: FAILED
./testbuild/mapping.yaml: FAILED
./testbuild/tileset.sql: OK
./testbuild/doc/housenumber.md: OK
./testbuild/sqlquery.sql: OK
./testbuild/devdoc/etl_housenumber.dot: OK
md5sum: WARNING: 2 computed checksums did NOT match
make: *** [test] Error 1
Makefile:7: recipe for target 'test' failed
The command '/bin/sh -c make test' returned a non-zero code: 2
make: *** [buildtest] Error 2
The command "make buildtest" exited with 2.
```