### PR TITLE
Merge import_sql repo and improve import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The `import_sql.sh` script can execute a single SQL file in Postgres when the fi
 If ran without any arguments, `import_sql.sh` executes all of the following:
 * SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
 * SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/mapbox/postgis-vt-util/blob/v1.0.0/postgis-vt-util.sql) helper functions.
-* SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. 
+* SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. If this directory contains `parallel/` subdirectory, `import_sql.sh` will assume the parallel/*.sql files are safe to execute in parallel, up to `MAX_PARALLEL_PSQL` at a time (defaults to 5). The script will also execute `run_first.sql` before, and `run_last.sql` after the files in `parallel/` dir (if they exist).
 
 Postgres connection requires `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_DB`, and optionally `POSTGRES_PORT` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenMapTiles Tools [![Build Status](https://api.travis-ci.org/openmaptiles/openmaptiles-tools.svg?branch=master)](https://travis-ci.org/openmaptiles/openmaptiles-tools) [![Docker Automated build](https://img.shields.io/docker/automated/openmaptiles/openmaptiles-tools.svg)](https://hub.docker.com/r/openmaptiles/openmaptiles-tools) [![](https://images.microbadger.com/badges/image/openmaptiles/openmaptiles-tools.svg)](https://microbadger.com/images/openmaptiles/openmaptiles-tools)
 
-The OpenMapTiles tools for generating TM2Source projects, imposm3 mappings and SQL instructions
+The OpenMapTiles toolbox for generating TM2Source projects, imposm3 mappings and SQL instructions
 from OpenMapTiles layers. We encourage other people to use this for their vector tile projects as well since this approach works well for us.
 
 Check out the [OpenMapTiles project](https://github.com/openmaptiles/openmaptiles/) for a real world example.
@@ -231,3 +231,23 @@ docker run -it --rm -u $(id -u ${USER}):$(id -g ${USER}) \
 Add `--help` to see all additional parameters.
 
 * Run Maputnik and set its data source to `http://localhost:8090`
+
+
+## Importing into Postgres
+The `import_sql.sh` script can execute a single SQL file in Postgres when the file is given as the first parameter.
+
+If ran without any arguments, `import_sql.sh` executes all of the following:
+* SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
+* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/mapbox/postgis-vt-util/blob/v1.0.0/postgis-vt-util.sql) helper functions.
+* SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. 
+
+Postgres connection requires `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_DB`, and optionally `POSTGRES_PORT` environment variables.
+
+Generating and importing SQL could be done in a single step with `&&`, e.g.
+
+```bash
+generate-sqltomvt openmaptiles.yaml > "$SQL_DIR/mvt.sql" && import_sql.sh
+```
+
+Optionally you may pass extra arguments to `psql` by using `PSQL_OPTIONS` environment variable. For example `PSQL_OPTIONS=-a` makes psql echo all commands read from a file into stdout.
+`PSQL_OPTIONS` allows multiple arguments as well, and understands quotes, e.g. you can pass a whole query as a single argument surrounded by quotes -- `PSQL_OPTIONS="-a -c 'SELECT ...'"`

--- a/bin/import_sql.sh
+++ b/bin/import_sql.sh
@@ -13,6 +13,7 @@ function exec_psql_file() {
 
     echo "Importing $file_name (md5 $(md5sum < "$file_name")  $(wc -l < "$file_name") lines) into Postgres..."
 
+    # shellcheck disable=SC2154
     PGPASSWORD="$POSTGRES_PASSWORD" psql \
         -v ON_ERROR_STOP="1" \
         --host="$POSTGRES_HOST" \
@@ -27,14 +28,50 @@ function exec_psql_file() {
 function import_all_sql_files() {
     local dir="$1"
     local sql_file
-    for sql_file in "$dir"/*.sql; do
+
+    if [[ -d "$dir/parallel" ]]; then
+      # Asseme this dir may contain run_first.sql, parallel/*.sql, and run_last.sql
+      # use parallel execution
+      if [[ -f "$dir/run_first.sql" ]]; then
+        exec_psql_file "$dir/run_first.sql"
+      else
+        echo "File $dir/run_first.sql not found, skipping"
+      fi
+
+      # Run import_sql script in parallel, up to MAX_PARALLEL_PSQL processes at the same time
+      : "${MAX_PARALLEL_PSQL:=5}"
+      echo "Importing $(find "$dir/parallel" -name "*.sql" | wc -l) sql files from $dir/parallel/, up to $MAX_PARALLEL_PSQL files at the same time"
+      find "$dir/parallel" -name "*.sql" -print0 | xargs -0 -I{} -P "$MAX_PARALLEL_PSQL" "$0" "{}"
+      echo "Finished importing sql files matching '$dir/parallel/*.sql'"
+
+      if [[ -f "$dir/run_last.sql" ]]; then
+        exec_psql_file "$dir/run_last.sql"
+      else
+        echo "File $dir/run_last.sql not found, skipping"
+      fi
+    else
+      for sql_file in "$dir"/*.sql; do
         exec_psql_file "$sql_file"
-    done
+      done
+    fi
 }
 
 # If there are no arguments, imports everything,
 # otherwise the first argument is the name of a file to be imported.
 if [[ $# -eq 0 ]]; then
+  if [[ "${OMT_UTIL_DIR:-}" == "" ]]; then
+    echo "ENV variable OMT_UTIL_DIR is not set. It should contain directory with .sql files, e.g. language.sql "
+    exit 1
+  fi
+  if [[ "${VT_UTIL_DIR:-}" == "" ]]; then
+    echo "ENV variable VT_UTIL_DIR is not set. It should contain directory with .sql files, e.g. postgis-vt-util.sql"
+    exit 1
+  fi
+  if [[ "${SQL_DIR:-}" == "" ]]; then
+    echo "ENV variable SQL_DIR is not set. It should contain directory with .sql files, e.g. tileset.sql, or run_first.sql, run_last.sql, and parallel/*.sql"
+    exit 1
+  fi
+
   import_all_sql_files "$OMT_UTIL_DIR"  # import language.sql
   import_all_sql_files "$VT_UTIL_DIR"  # import postgis-vt-util.sql
   import_all_sql_files "$SQL_DIR"  # import compiled tileset.sql

--- a/bin/import_sql.sh
+++ b/bin/import_sql.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+shopt -s nullglob
+
+function exec_psql_file() {
+    local file_name="$1"
+    # Allws additional parameters to be passed to psql
+    # For example, PSQL_OPTIONS='-a -A' would echo everything and disable output alignment
+    # Using eval allows complex cases with quotes, like PSQL_OPTIONS=" -a -c 'select ...' "
+    eval "local psql_opts=(${PSQL_OPTIONS:-})"
+
+    echo "Importing $file_name (md5 $(md5sum < "$file_name")  $(wc -l < "$file_name") lines) into Postgres..."
+
+    PGPASSWORD="$POSTGRES_PASSWORD" psql \
+        -v ON_ERROR_STOP="1" \
+        --host="$POSTGRES_HOST" \
+        ${POSTGRES_PORT:+ --port="$POSTGRES_PORT"} \
+        --dbname="$POSTGRES_DB" \
+        --username="$POSTGRES_USER" \
+        -c '\timing on' \
+        -f "$file_name" \
+        "${psql_opts[@]}"
+}
+
+function import_all_sql_files() {
+    local dir="$1"
+    local sql_file
+    for sql_file in "$dir"/*.sql; do
+        exec_psql_file "$sql_file"
+    done
+}
+
+# If there are no arguments, imports everything,
+# otherwise the first argument is the name of a file to be imported.
+if [[ $# -eq 0 ]]; then
+  import_all_sql_files "$OMT_UTIL_DIR"  # import language.sql
+  import_all_sql_files "$VT_UTIL_DIR"  # import postgis-vt-util.sql
+  import_all_sql_files "$SQL_DIR"  # import compiled tileset.sql
+else
+  exec_psql_file "$1"
+fi

--- a/sql/language.sql
+++ b/sql/language.sql
@@ -1,0 +1,162 @@
+-- This file was migrated from https://github.com/openmaptiles/import-sql/blob/master/language.sql
+
+CREATE OR REPLACE FUNCTION delete_empty_keys(tags hstore) RETURNS hstore AS $$
+DECLARE
+  result hstore;
+BEGIN
+  select
+    hstore(array_agg(key), array_agg(value)) into result
+  from
+    each(hstore(tags))
+  where nullif(value, '') is not null;
+  RETURN result;
+END;
+$$ STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION remove_latin(text) RETURNS text AS $$
+  DECLARE
+    i integer;
+  DECLARE
+    letter text;
+    result text = '';
+  BEGIN
+    FOR i IN 1..char_length($1) LOOP
+      letter := substr($1, i, 1);
+      IF (unaccent(letter) !~ '^[a-zA-Z].*') THEN
+        result := result || letter;
+      END IF;
+    END LOOP;
+    result := regexp_replace(result, '(\([ -.]*\)|\[[ -.]*\])', '');
+    result := regexp_replace(result, ' +\. *$', '');
+    result := trim(both ' -\n' from result);
+    RETURN result;
+  END;
+$$ LANGUAGE 'plpgsql' IMMUTABLE;
+
+-- See osml10n_is_latin
+-- https://github.com/giggls/mapnik-german-l10n/blob/ea5da9cdfa6c931ae73eac747849140547ecd321/plpgsql/get_localized_name.sql#L19
+CREATE or REPLACE FUNCTION omt_is_latin(text) RETURNS BOOLEAN AS $$
+  DECLARE
+    i integer;
+    ascii_val int;
+  BEGIN
+    FOR i IN 1..char_length($1) LOOP
+      ascii_val := ascii(substr($1, i, 1));
+      IF (ascii_val > 591
+          -- Vietnam
+          -- https://en.wikipedia.org/wiki/Latin_script_in_Unicode
+          -- https://en.wikipedia.org/wiki/Latin_Extended_Additional
+          AND ascii_val NOT BETWEEN x'1E00'::int AND x'1EFF'::int
+          -- https://en.wikipedia.org/wiki/Combining_character
+          AND ascii_val NOT BETWEEN x'0300'::int AND x'036F'::int
+
+          -- Azerbaijan
+          -- https://en.wikipedia.org/wiki/IPA_Extensions
+          AND ascii_val <> x'0259'::int
+      ) THEN
+        RETURN false;
+      END IF;
+    END LOOP;
+    RETURN true;
+  END;
+$$ LANGUAGE 'plpgsql' IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION get_latin_name(tags hstore, geometry geometry) RETURNS text AS $$
+    SELECT COALESCE(
+      CASE
+        WHEN tags->'name' is not null and omt_is_latin(tags->'name')
+          THEN tags->'name'
+        ELSE NULL
+      END,
+      NULLIF(tags->'name:en', ''),
+      NULLIF(tags->'int_name', ''),
+      NULLIF(osml10n_get_name_without_brackets_from_tags(tags, 'en', geometry), '')
+    );
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+
+
+CREATE OR REPLACE FUNCTION get_nonlatin_name(tags hstore) RETURNS text AS $$
+    SELECT
+      CASE
+        WHEN tags->'name' is not null and omt_is_latin(tags->'name')
+          THEN NULL
+        WHEN unaccent(tags->'name') ~ '[a-zA-Z]'
+          THEN remove_latin(tags->'name')
+        ELSE tags->'name'
+      END;
+$$ LANGUAGE SQL IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION get_basic_names(tags hstore, geometry geometry) RETURNS hstore AS $$
+DECLARE
+  tags_array text[] := ARRAY[]::text[];
+  name_latin text;
+  name_nonlatin text;
+  name_int text;
+BEGIN
+  name_latin := get_latin_name(tags, geometry);
+  name_nonlatin := get_nonlatin_name(tags);
+  IF (name_nonlatin = name_latin) THEN
+    name_nonlatin := null;
+  END IF;
+  name_int := COALESCE(
+    NULLIF(tags->'int_name', ''),
+    NULLIF(tags->'name:en', ''),
+    NULLIF(name_latin, ''),
+    tags->'name'
+  );
+  IF name_latin IS NOT NULL THEN
+    tags_array := tags_array || ARRAY['name:latin', name_latin];
+  END IF;
+  IF name_nonlatin IS NOT NULL THEN
+    tags_array := tags_array || ARRAY['name:nonlatin', name_nonlatin];
+  END IF;
+  IF name_int IS NOT NULL THEN
+    tags_array := tags_array || ARRAY['name_int', name_int];
+  END IF;
+  RETURN hstore(tags_array);
+END;
+$$ STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
+CREATE TABLE IF NOT EXISTS wd_names(id varchar(20), page varchar(200), labels hstore);
+
+CREATE OR REPLACE FUNCTION merge_wiki_names(tags hstore) RETURNS hstore AS $$
+DECLARE
+  result hstore;
+BEGIN
+
+  IF (tags ? 'wikidata' OR tags ? 'wikipedia') THEN
+    select INTO result
+    CASE
+      WHEN avals(wd.labels) && avals(tags)
+        THEN slice_language_tags(wd.labels) || tags
+      ELSE tags
+    END
+    FROM wd_names wd
+    WHERE wd.id = tags->'wikidata' OR wd.page = tags->'wikipedia';
+    IF result IS NULL THEN
+      result := tags;
+    END IF;
+  ELSE
+    result := tags;
+  END IF;
+
+  RETURN result;
+END;
+$$ STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
+
+CREATE OR REPLACE FUNCTION update_tags(tags hstore, geometry
+  geometry) RETURNS hstore AS $$
+DECLARE
+  result hstore;
+BEGIN
+  result := delete_empty_keys(tags) || get_basic_names(tags, geometry);
+  result := merge_wiki_names(result);
+  RETURN result;
+END;
+$$ STRICT
+LANGUAGE plpgsql IMMUTABLE;


### PR DESCRIPTION
Upgraded to python 3.7 base, copied import_sql and language.sql, made a number of script improvements, i.e. now it imports all sql files from the well known directories.  From the new readme section:

## Importing into Postgres
The `import_sql.sh` script can execute a single SQL file in Postgres when the file is given as the first parameter.

If ran without any arguments, `import_sql.sh` executes all of the following:
* SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/mapbox/postgis-vt-util/blob/v1.0.0/postgis-vt-util.sql) helper functions.
* SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. 

Postgres connection requires `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_DB`, and optionally `POSTGRES_PORT` environment variables.

Generating and importing SQL could be done in a single step with `&&`, e.g.

```bash
generate-sqltomvt openmaptiles.yaml > "$SQL_DIR/mvt.sql" && import_sql.sh
```

Optionally you may pass extra arguments to `psql` by using `PSQL_OPTIONS` environment variable. For example `PSQL_OPTIONS=-a` makes psql echo all commands read from a file into stdout.
`PSQL_OPTIONS` allows multiple arguments as well, and understands quotes, e.g. you can pass a whole query as a single argument surrounded by quotes -- `PSQL_OPTIONS="-a -c 'SELECT ...'"`