### PR TITLE
Generate-sql can now produce multiple sql files for parallel execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ build-tests: \
     build/tm2source.yml \
     build/imposm3.yaml \
     build/sql.sql \
+    build/parallel_sql \
     build/mvttile_func.sql \
     build/mvttile_zd_func.sql \
     build/mvttile_prep.sql \
@@ -62,6 +63,8 @@ build/imposm3.yaml: prepare
 	$(RUN_CMD) generate-imposm3  testdata/testlayers/testmaptiles.yaml                               > build/imposm3.yaml
 build/sql.sql: prepare
 	$(RUN_CMD) generate-sql      testdata/testlayers/testmaptiles.yaml                               > build/sql.sql
+build/parallel_sql: prepare
+	$(RUN_CMD) generate-sql      testdata/testlayers/testmaptiles.yaml --dir build/parallel_sql
 build/mvttile_func.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml                               > build/mvttile_func.sql
 build/mvttile_zd_func.sql: prepare

--- a/README.md
+++ b/README.md
@@ -141,12 +141,14 @@ Takes a tileset definition an generates an imposm3 mapping file for importing OS
 generate-imposm3 <tileset>
 ```
 
-### Collect SQL schemas
+### Generate SQL scripts
 
-Takes a tileset definition and collects all SQL referenced in the layer definitions.
+Assembles all SQL referenced in the layer definitions into an SQL script that can be executed with psql.
+If `--dir` option  is given, generates `.sql` files that can be executed in parallel.
 
 ```
 generate-sql <tileset>
+generate-sql <tileset> --dir <outputdir>
 ```
 
 ### Generate Markdown Documentation

--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     if not args['--dir']:
         print(collect_sql(args['<tileset>']))
     else:
-        init_sql, parallel_sql = collect_sql(args['<tileset>'], parallel=True)
+        run_first, parallel_sql, run_last  = collect_sql(args['<tileset>'], parallel=True)
 
         path = Path(args['--dir'])
         path.mkdir(parents=True, exist_ok=True)
@@ -39,7 +39,8 @@ if __name__ == '__main__':
         if deleted_files:
             print(f"Remvoed {deleted_files} existing files in dir {parallel_dir}")
 
-        (path / 'run_first.sql').write_text(init_sql)
+        (path / 'run_first.sql').write_text(run_first)
+        (path / 'run_last.sql').write_text(run_last)
         for idx, sql in enumerate(parallel_sql):
             (parallel_dir / f'{idx:03}.sql').write_text(sql)
         print(f'Created {len(parallel_sql)} sql files for parallel execution and a common file in dir {path}')

--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -26,7 +26,6 @@ if __name__ == '__main__':
 
         path = Path(args['--dir'])
         path.mkdir(parents=True, exist_ok=True)
-        (path / 'run_first.sql').write_text(init_sql)
         parallel_dir = path / 'parallel'
         parallel_dir.mkdir(exist_ok=True)
 
@@ -40,6 +39,7 @@ if __name__ == '__main__':
         if deleted_files:
             print(f"Remvoed {deleted_files} existing files in dir {parallel_dir}")
 
+        (path / 'run_first.sql').write_text(init_sql)
         for idx, sql in enumerate(parallel_sql):
             (parallel_dir / f'{idx:03}.sql').write_text(sql)
         print(f'Created {len(parallel_sql)} sql files for parallel execution and a common file in dir {path}')

--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -16,13 +16,13 @@ from docopt import docopt
 import openmaptiles
 from openmaptiles.sql import collect_sql
 
-
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
     if not args['--dir']:
         print(collect_sql(args['<tileset>']))
     else:
-        run_first, parallel_sql, run_last  = collect_sql(args['<tileset>'], parallel=True)
+        run_first, parallel_sql, run_last = collect_sql(
+            args['<tileset>'], parallel=True)
 
         path = Path(args['--dir'])
         path.mkdir(parents=True, exist_ok=True)
@@ -37,10 +37,10 @@ if __name__ == '__main__':
             else:
                 print(f"Unexpected file {file} is ignored")
         if deleted_files:
-            print(f"Remvoed {deleted_files} existing files in dir {parallel_dir}")
+            print(f"Removed {deleted_files} existing files in dir {parallel_dir}")
 
         (path / 'run_first.sql').write_text(run_first)
         (path / 'run_last.sql').write_text(run_last)
         for idx, sql in enumerate(parallel_sql):
             (parallel_dir / f'{idx:03}.sql').write_text(sql)
-        print(f'Created {len(parallel_sql)} sql files for parallel execution and a common file in dir {path}')
+        print(f'Created {len(parallel_sql)} sql files for parallel execution at {path}')

--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 """
 Usage:
-  generate-sql <tileset>
+  generate-sql <tileset> [--dir <dir>]
   generate-sql --help
   generate-sql --version
+
 Options:
+  -d --dir=<dir>      Output multiple sql files into this directory. Prints to STDOUT by default.
   --help              Show this screen.
   --version           Show version.
 """
+import re
+from pathlib import Path
 from docopt import docopt
 import openmaptiles
 from openmaptiles.sql import collect_sql
@@ -15,5 +19,27 @@ from openmaptiles.sql import collect_sql
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
-    sql = collect_sql(args['<tileset>'])
-    print(sql)
+    if not args['--dir']:
+        print(collect_sql(args['<tileset>']))
+    else:
+        init_sql, parallel_sql = collect_sql(args['<tileset>'], parallel=True)
+
+        path = Path(args['--dir'])
+        path.mkdir(parents=True, exist_ok=True)
+        (path / 'run_first.sql').write_text(init_sql)
+        parallel_dir = path / 'parallel'
+        parallel_dir.mkdir(exist_ok=True)
+
+        deleted_files = 0
+        for file in parallel_dir.glob('*.sql'):
+            if re.match(r'^\d+\.sql$', file.name):
+                file.unlink()
+                deleted_files += 1
+            else:
+                print(f"Unexpected file {file} is ignored")
+        if deleted_files:
+            print(f"Remvoed {deleted_files} existing files in dir {parallel_dir}")
+
+        for idx, sql in enumerate(parallel_sql):
+            (parallel_dir / f'{idx:03}.sql').write_text(sql)
+        print(f'Created {len(parallel_sql)} sql files for parallel execution and a common file in dir {path}')

--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -1,19 +1,28 @@
 from .tileset import Tileset
 
 
-def collect_sql(tileset_filename):
+def collect_sql(tileset_filename, parallel=False):
+    """If parallel is True, returns a sql value that must be executed first,
+        and a lists of sql values that can be ran in parallel.
+        If parallel is False, returns a single sql string"""
     tileset = Tileset.parse(tileset_filename)
-    sql = ''
 
     definition = tileset.definition
     languages = map(lambda l: str(l), definition.get('languages', []))
-    sql += get_slice_language_tags(languages)
+    shared_sql = get_slice_language_tags(languages)
+
+    parallel_sql = []
 
     for layer in tileset.layers:
-        sql += layer_notice(layer['layer']['id'])
+        sql = layer_notice(layer['layer']['id'])
         for schema in layer.schemas:
             sql += schema
-    return sql
+        parallel_sql.append(schema)
+
+    if parallel:
+        return shared_sql, parallel_sql
+    else:
+        return shared_sql + ''.join(parallel_sql)
 
 
 def layer_notice(layer_name):

--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -17,7 +17,7 @@ def collect_sql(tileset_filename, parallel=False):
         sql = layer_notice(layer['layer']['id'])
         for schema in layer.schemas:
             sql += schema
-        parallel_sql.append(schema)
+        parallel_sql.append(sql)
 
     if parallel:
         return shared_sql, parallel_sql

--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -9,10 +9,10 @@ def collect_sql(tileset_filename, parallel=False):
 
     definition = tileset.definition
     languages = map(lambda l: str(l), definition.get('languages', []))
-    shared_sql = get_slice_language_tags(languages)
+    run_first = get_slice_language_tags(languages)
+    run_last = ''  # at this point we don't have any SQL to run at the end
 
     parallel_sql = []
-
     for layer in tileset.layers:
         sql = layer_notice(layer['layer']['id'])
         for schema in layer.schemas:
@@ -20,9 +20,9 @@ def collect_sql(tileset_filename, parallel=False):
         parallel_sql.append(sql)
 
     if parallel:
-        return shared_sql, parallel_sql
+        return run_first, parallel_sql, run_last
     else:
-        return shared_sql + ''.join(parallel_sql)
+        return run_first + ''.join(parallel_sql) + run_last
 
 
 def layer_notice(layer_name):

--- a/testdata/expected/parallel_sql/parallel/000.sql
+++ b/testdata/expected/parallel_sql/parallel/000.sql
@@ -1,4 +1,5 @@
-DO $$ BEGIN RAISE NOTICE 'Layer housenumber'; END$$;
+DO $$ BEGIN RAISE NOTICE 'Processing layer housenumber'; END$$;
+
 -- etldoc: osm_housenumber_point -> osm_housenumber_point
 UPDATE osm_housenumber_point SET geometry=topoint(geometry)
 WHERE ST_GeometryType(geometry) <> 'ST_Point';
@@ -12,3 +13,5 @@ RETURNS TABLE(osm_id bigint, geometry geometry, housenumber text, tags hstore) A
     SELECT osm_id, geometry, housenumber, tags FROM osm_housenumber_point
     WHERE zoom_level >= 14 AND geometry && bbox;
 $$ LANGUAGE SQL IMMUTABLE;
+
+DO $$ BEGIN RAISE NOTICE 'Finished layer housenumber'; END$$;

--- a/testdata/expected/parallel_sql/parallel/000.sql
+++ b/testdata/expected/parallel_sql/parallel/000.sql
@@ -1,0 +1,14 @@
+DO $$ BEGIN RAISE NOTICE 'Layer housenumber'; END$$;
+-- etldoc: osm_housenumber_point -> osm_housenumber_point
+UPDATE osm_housenumber_point SET geometry=topoint(geometry)
+WHERE ST_GeometryType(geometry) <> 'ST_Point';
+
+-- etldoc: layer_housenumber[shape=record fillcolor=lightpink, style="rounded,filled",
+-- etldoc:     label="layer_housenumber | <z14_> z14_" ] ;
+
+CREATE OR REPLACE FUNCTION layer_housenumber(bbox geometry, zoom_level integer)
+RETURNS TABLE(osm_id bigint, geometry geometry, housenumber text, tags hstore) AS $$
+   -- etldoc: osm_housenumber_point -> layer_housenumber:z14_
+    SELECT osm_id, geometry, housenumber, tags FROM osm_housenumber_point
+    WHERE zoom_level >= 14 AND geometry && bbox;
+$$ LANGUAGE SQL IMMUTABLE;

--- a/testdata/expected/parallel_sql/run_first.sql
+++ b/testdata/expected/parallel_sql/run_first.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE FUNCTION slice_language_tags(tags hstore)
+RETURNS hstore AS $$
+    SELECT delete_empty_keys(slice(tags, ARRAY['name:en', 'name:de', 'name:cs', 'int_name', 'loc_name', 'name', 'wikidata', 'wikipedia']))
+$$ LANGUAGE SQL IMMUTABLE;

--- a/testdata/expected/sql.sql
+++ b/testdata/expected/sql.sql
@@ -2,7 +2,8 @@ CREATE OR REPLACE FUNCTION slice_language_tags(tags hstore)
 RETURNS hstore AS $$
     SELECT delete_empty_keys(slice(tags, ARRAY['name:en', 'name:de', 'name:cs', 'int_name', 'loc_name', 'name', 'wikidata', 'wikipedia']))
 $$ LANGUAGE SQL IMMUTABLE;
-DO $$ BEGIN RAISE NOTICE 'Layer housenumber'; END$$;
+DO $$ BEGIN RAISE NOTICE 'Processing layer housenumber'; END$$;
+
 -- etldoc: osm_housenumber_point -> osm_housenumber_point
 UPDATE osm_housenumber_point SET geometry=topoint(geometry)
 WHERE ST_GeometryType(geometry) <> 'ST_Point';
@@ -16,4 +17,6 @@ RETURNS TABLE(osm_id bigint, geometry geometry, housenumber text, tags hstore) A
     SELECT osm_id, geometry, housenumber, tags FROM osm_housenumber_point
     WHERE zoom_level >= 14 AND geometry && bbox;
 $$ LANGUAGE SQL IMMUTABLE;
+
+DO $$ BEGIN RAISE NOTICE 'Finished layer housenumber'; END$$;
 


### PR DESCRIPTION
This allows psql to run them in parallel during the import, speeding up the process.