### PR TITLE
Refactoring MVT, Postserve, validates fields against live PG

### DIFF
--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -25,27 +25,26 @@ Options:
 """
 from docopt import docopt
 import openmaptiles
-from openmaptiles.sqltomvt import *
+from openmaptiles.sqltomvt import MvtGenerator
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
-    opts = {
-        'tileset': args['<tileset>'],
-        'fname': args['--fname'],
-        'mask-layer': args['--mask-layer'],
-        'mask-zoom': int(args['--mask-zoom']),
-    }
+    mvt = MvtGenerator(
+        tileset=args['<tileset>'],
+        mask_layer=args['--mask-layer'],
+        mask_zoom=int(args['--mask-zoom']),
+    )
 
     if args['--prepared']:
-        sql = generate_sqltomvt_preparer(opts)
+        sql = mvt.generate_sqltomvt_preparer(args['--fname'])
     elif args['--query']:
-        sql = generate_sqltomvt_query(opts)
+        sql = mvt.generate_sqltomvt_query()
     elif args['--psql']:
-        sql = generate_sqltomvt_psql(opts)
+        sql = mvt.generate_sqltomvt_psql()
     elif args['--raw']:
-        sql = generate_sqltomvt_raw(opts)
+        sql = mvt.generate_sqltomvt_raw()
     else:
         # --function or default
-        sql = generate_sqltomvt_func(opts)
+        sql = mvt.generate_sqltomvt_func(args['--fname'])
 
     print(sql)

--- a/bin/postserve
+++ b/bin/postserve
@@ -5,12 +5,14 @@ This is a simple vector tile server that returns a PBF tile for  /tiles/{z}/{x}/
 Usage:
   postserve <tileset> [--mask-layer=<layer> --mask-zoom=<z>] [--serve=<host>] [--port=<port>] [--file=<sql-file>] [--verbose]
                       [--pghost=<host>] [--pgport=<port>] [--dbname=<db>] [--user=<user>] [--password=<password>]
+                      [--layer=<layer>]...
   postserve --help
   postserve --version
 
   <tileset>             Tileset definition yaml file
 
 Options:
+  -l --layer=<layer>    If set, limit tile generation to just this layer (could be multiple)
   --mask-layer=<layer>  If tile only has this layer covering for the whole tile (e.g. 'water'),
                         and requested zoom is more than --mask-zoom parameter, returns empty result
   --mask-zoom=<z>       If --mask-layer is set, tiles will be checked for empty after given zoom  [default: 8]
@@ -36,7 +38,7 @@ Additional ENV variables:
 from docopt import docopt
 import os.path
 import openmaptiles
-from openmaptiles.postserve import serve
+from openmaptiles.postserve import Postserve
 from openmaptiles.utils import Bbox, coalesce
 from openmaptiles.consts import *
 
@@ -65,7 +67,7 @@ if __name__ == '__main__':
         mask_zoom = int(args['--mask-zoom'])
         metadata['maskLevel'] = mask_zoom
 
-    serve(
+    Postserve(
         host=args['--serve'],
         port=int(args['--port']),
         pghost=coalesce(
@@ -84,9 +86,10 @@ if __name__ == '__main__':
             args.get("--password"), os.getenv('POSTGRES_PASSWORD'),
             os.getenv('PGPASSWORD'), 'openmaptiles'),
         metadata=metadata,
+        layers=args['--layer'],
         tileset_path=args['<tileset>'],
         sql_file=args.get('--file'),
         mask_layer=mask_layer,
         mask_zoom=mask_zoom,
         verbose=args.get('--verbose'),
-    )
+    ).serve()

--- a/openmaptiles/language.py
+++ b/openmaptiles/language.py
@@ -1,7 +1,12 @@
 def languages_to_sql(languages):
-    name_languages = list(map(lambda l: "NULLIF(tags->'name:" + l + "', '') AS \"name:" + l + "\"", languages))
-    name_languages.append("NULLIF(tags->'name_int', '') AS \"name_int\"")
-    name_languages.append("NULLIF(tags->'name:latin', '') AS \"name:latin\"")
-    name_languages.append("NULLIF(tags->'name:nonlatin', '') AS \"name:nonlatin\"")
-    name_languages = ', '.join(name_languages)
-    return name_languages
+    return ', '.join(languages_as_fields(languages))
+
+
+def languages_as_fields(languages):
+    return [f"NULLIF(tags->'{l}', '') AS \"{l}\"" for l in
+            language_codes_to_names(languages)]
+
+
+def language_codes_to_names(languages):
+    return [f"name:{lang}" for lang in languages] + \
+           ['name_int', 'name:latin', 'name:nonlatin']

--- a/openmaptiles/postserve.py
+++ b/openmaptiles/postserve.py
@@ -9,8 +9,8 @@ from asyncpg import Connection, ConnectionDoesNotExistError
 from asyncpg.pool import Pool
 
 from openmaptiles.consts import PIXEL_SCALE
-from openmaptiles.language import languages_to_sql
-from openmaptiles.sqltomvt import generate_sqltomvt_query
+from openmaptiles.language import languages_to_sql, language_codes_to_names
+from openmaptiles.sqltomvt import MvtGenerator
 from openmaptiles.tileset import Tileset
 
 
@@ -46,7 +46,12 @@ class GetTile(RequestHandledWithCors):
         try:
             async with self.pool.acquire() as connection:
                 self.connection = connection
-                tile = await connection.fetchval(self.query, int(zoom), int(x), int(y))
+                query = self.query
+                zoom, x, y = int(zoom), int(x), int(y)
+                if self.verbose:
+                    # Make it easier to track queries in pg_stat_activity table
+                    query = f"/* {zoom}/{x}/{y} */ " + query
+                tile = await connection.fetchval(query, zoom, x, y)
                 if tile:
                     self.write(tile)
                 else:
@@ -79,84 +84,132 @@ class GetMetadata(RequestHandledWithCors):
         print('Returning metadata')
 
 
-async def generate_metadata(pool, tileset, host, port, metadata):
-    async with pool.acquire() as connection:
-        # Get all Postgres types and keep those we know about
-        known_types = dict(bool="Boolean", text="String", int4="Number", int8="Number")
-        types = await connection.fetch("select oid, typname from pg_type")
-        pg_types = {row[0]: known_types[row[1]] for row in types if
-                    row[1] in known_types}
+class Postserve:
+    known_types = dict(bool="Boolean", text="String", int4="Number", int8="Number")
+    pool: Pool
 
-        vector_layers = []
-        for layer_def in tileset.layers:
-            layer = layer_def["layer"]
+    def __init__(self, host, port, pghost, pgport, dbname, user, password, metadata,
+                 layers, tileset_path, sql_file, mask_layer, mask_zoom, verbose):
+        self.host = host
+        self.port = port
+        self.pghost = pghost
+        self.pgport = pgport
+        self.dbname = dbname
+        self.user = user
+        self.password = password
+        self.metadata = metadata
+        self.layers = layers
+        self.tileset_path = tileset_path
+        self.sql_file = sql_file
+        self.mask_layer = mask_layer
+        self.mask_zoom = mask_zoom
+        self.verbose = verbose
 
-            # Get field names and types by executing a dummy query
-            langs = languages_to_sql(tileset.definition.get('languages', []))
-            query = (layer['datasource']['query']
-                     .format(name_languages=langs)
-                     .replace("!bbox!", "TileBBox(0, 0, 0)")
-                     .replace("z(!scale_denominator!)", "0")
-                     .replace("!pixel_width!", str(PIXEL_SCALE))
-                     .replace("!pixel_height!", str(PIXEL_SCALE)))
-            st = await connection.prepare(f"SELECT * FROM {query} WHERE false LIMIT 0")
+        self.tileset = Tileset.parse(self.tileset_path)
+
+    async def generate_metadata(self):
+        async with self.pool.acquire() as connection:
+            # Get all Postgres types and keep those we know about
+            types = await connection.fetch("select oid, typname from pg_type")
+            pg_types = {row[0]: self.known_types[row[1]] for row in types
+                        if row[1] in self.known_types}
+
+            vector_layers = []
+            for layer_def in self.tileset.layers:
+                layer = layer_def["layer"]
+
+                # Get field names and types by executing a dummy query
+                query = layer['datasource']['query']
+                if '{name_languages}' in query:
+                    languages = self.tileset.definition.get('languages', [])
+                else:
+                    languages = False
+                if languages:
+                    query = query.format(name_languages=languages_to_sql(languages))
+                query = (query
+                         .replace("!bbox!", "TileBBox(0, 0, 0)")
+                         .replace("z(!scale_denominator!)", "0")
+                         .replace("!pixel_width!", str(PIXEL_SCALE))
+                         .replace("!pixel_height!", str(PIXEL_SCALE)))
+                st = await connection.prepare(
+                    f"SELECT * FROM {query} WHERE false LIMIT 0")
+
+                query_fields = {v.name for v in st.get_attributes()}
+                layer_fields, geometry_field = layer_def.get_fields()
+                if languages:
+                    layer_fields += language_codes_to_names(languages)
+                layer_fields = set(layer_fields)
+
+                if geometry_field not in query_fields:
+                    raise ValueError(f"Layer '{layer['id']}' query does not generate "
+                                     f"expected 'geometry' field")
+                query_fields.remove(geometry_field)
+
+                if layer_fields != query_fields:
+                    same = layer_fields.intersection(query_fields)
+                    layer_fields -= same
+                    query_fields -= same
+                    error = f"Declared fields in layer '{layer['id']}' do not match " \
+                            f"the fields received from a query:\n"
+                    if layer_fields:
+                        error += f"  These fields were declared, but not returned by " \
+                                 f"the query: {', '.join(layer_fields)}"
+                    if query_fields:
+                        error += f"  These fields were returned by the query, " \
+                                 f"but not declared: {', '.join(query_fields)}"
+                    raise ValueError(error)
+
             fields = {fld.name: pg_types[fld.type.oid]
                       for fld in st.get_attributes() if fld.type.oid in pg_types}
-
             vector_layers.append(dict(
                 id=layer["id"],
                 fields=fields,
-                maxzoom=metadata["maxzoom"],
-                minzoom=metadata["minzoom"],
+                maxzoom=self.metadata["maxzoom"],
+                minzoom=self.metadata["minzoom"],
                 description=layer["description"],
             ))
 
-        metadata["vector_layers"] = vector_layers
-        metadata["tiles"] = [f"http://{host}:{port}" + "/tiles/{z}/{x}/{y}.pbf"]
+        self.metadata["vector_layers"] = vector_layers
+        self.metadata["tiles"] = [
+            f"http://{self.host}:{self.port}" + "/tiles/{z}/{x}/{y}.pbf",
+        ]
 
+    def serve(self):
+        if self.sql_file:
+            with open(self.sql_file) as stream:
+                query = stream.read()
+            print(f'Loaded {self.sql_file}')
+        else:
+            mvt = MvtGenerator(self.tileset, self.mask_layer, self.mask_zoom,
+                               layer_ids=self.layers)
+            query = mvt.generate_sqltomvt_query()
 
-def serve(host, port, pghost, pgport, dbname, user, password, metadata, tileset_path,
-          sql_file, mask_layer, mask_zoom, verbose):
-    tileset = Tileset.parse(tileset_path)
+        if self.verbose:
+            print(f'Using SQL query:\n\n-------\n\n{query}\n\n-------\n\n')
 
-    if sql_file:
-        with open(sql_file) as stream:
-            query = stream.read()
-        print(f'Loaded {sql_file}')
-    else:
-        query = generate_sqltomvt_query({
-            'tileset': tileset,
-            'mask-layer': mask_layer,
-            'mask-zoom': mask_zoom,
-        })
+        tornado.log.access_log.setLevel(logging.INFO if self.verbose else logging.ERROR)
 
-    if verbose:
-        print(f'Using SQL query:\n\n-------\n\n{query}\n\n-------\n\n')
+        dsn = f"postgresql://{self.user}:{self.password}@" \
+              f"{self.pghost}:{self.pgport}/{self.dbname}"
 
-    tornado.log.access_log.setLevel(logging.INFO if verbose else logging.ERROR)
+        io_loop = tornado.ioloop.IOLoop.current()
+        self.pool = io_loop.run_sync(partial(asyncpg.create_pool, dsn=dsn))
+        io_loop.run_sync(partial(self.generate_metadata))
 
-    dsn = f"postgresql://{user}:{password}@{pghost}:{pgport}/{dbname}"
+        application = tornado.web.Application([
+            (
+                r"/",
+                GetMetadata,
+                dict(metadata=self.metadata)
+            ),
+            (
+                r"/tiles/([0-9]+)/([0-9]+)/([0-9]+).pbf",
+                GetTile,
+                dict(pool=self.pool, query=query, verbose=self.verbose)
+            ),
+        ])
 
-    io_loop = tornado.ioloop.IOLoop.current()
-    pool = io_loop.run_sync(partial(asyncpg.create_pool, dsn=dsn))
-    io_loop.run_sync(
-        partial(generate_metadata, pool=pool, tileset=tileset, host=host, port=port,
-                metadata=metadata))
-
-    application = tornado.web.Application([
-        (
-            r"/",
-            GetMetadata,
-            dict(metadata=metadata)
-        ),
-        (
-            r"/tiles/([0-9]+)/([0-9]+)/([0-9]+).pbf",
-            GetTile,
-            dict(pool=pool, query=query, verbose=verbose)
-        ),
-    ])
-
-    application.listen(port)
-    print(f"Postserve started, listening on 0.0.0.0:{port}")
-    print(f"Use http://{host}:{port} as the data source")
-    tornado.ioloop.IOLoop.instance().start()
+        application.listen(self.port)
+        print(f"Postserve started, listening on 0.0.0.0:{self.port}")
+        print(f"Use http://{self.host}:{self.port} as the data source")
+        tornado.ioloop.IOLoop.instance().start()

--- a/openmaptiles/sqltomvt.py
+++ b/openmaptiles/sqltomvt.py
@@ -1,137 +1,153 @@
 from .consts import PIXEL_SCALE
-from .tileset import Tileset
 from .language import languages_to_sql
+from .tileset import Tileset
 
 
-def generate_sqltomvt_func(opts):
-    """
-    Creates a SQL function that returns a single bytea value or null
-    """
-    return f"""\
-CREATE OR REPLACE FUNCTION {opts['fname']}(zoom integer, x integer, y integer)
+class MvtGenerator:
+    def __init__(self, tileset, mask_layer=None, mask_zoom=8, layer_ids=None):
+        if isinstance(tileset, str):
+            self.tileset = Tileset.parse(tileset)
+        else:
+            self.tileset = tileset
+        self.mask_layer = mask_layer
+        self.mask_zoom = mask_zoom
+        self.extent = 4096
+        self.pixel_width = PIXEL_SCALE
+        self.pixel_height = PIXEL_SCALE
+        self.layers_ids = set(layer_ids or [])
+
+    def generate_sqltomvt_func(self, fname):
+        """
+        Creates a SQL function that returns a single bytea value or null
+        """
+        return f"""\
+CREATE OR REPLACE FUNCTION {fname}(zoom integer, x integer, y integer)
 RETURNS bytea AS $$
-{generate_query(opts, "TileBBox(zoom, x, y)", "zoom")};
+{self.generate_query("TileBBox(zoom, x, y)", "zoom")};
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;"""
 
-
-def generate_sqltomvt_preparer(opts):
-    """
-    Creates a SQL prepared statement that returns 0 or 1 row with a single mvt column.
-    """
-    return f"""\
+    def generate_sqltomvt_preparer(self, fname):
+        """
+        Creates a SQL prepared statement that returns 0 or 1 row with a single mvt column.
+        """
+        return f"""\
 -- Delete prepared statement if it already exists
 DO $$ BEGIN
-IF EXISTS (SELECT * FROM pg_prepared_statements where name = '{opts['fname']}') THEN
-  DEALLOCATE {opts['fname']};
+IF EXISTS (SELECT * FROM pg_prepared_statements where name = '{fname}') THEN
+  DEALLOCATE {fname};
 END IF;
 END $$;
 
--- Run this statement with   EXECUTE {opts['fname']}(zoom, x, y)
-PREPARE {opts['fname']}(integer, integer, integer) AS
-{generate_sqltomvt_query(opts)};"""
+-- Run this statement with   EXECUTE {fname}(zoom, x, y)
+PREPARE {fname}(integer, integer, integer) AS
+{self.generate_sqltomvt_query()};"""
 
+    def generate_sqltomvt_query(self):
+        return self.generate_query("TileBBox($1, $2, $3)", "$1")
 
-def generate_sqltomvt_query(opts):
-    return generate_query(opts, "TileBBox($1, $2, $3)", "$1")
+    def generate_sqltomvt_psql(self):
+        return self.generate_query("TileBBox(:zoom, :x, :y)", ":zoom")
 
+    def generate_sqltomvt_raw(self):
+        return self.generate_query(None, None)
 
-def generate_sqltomvt_psql(opts):
-    return generate_query(opts, "TileBBox(:zoom, :x, :y)", ":zoom")
+    def generate_query(self, bbox, zoom):
+        queries = []
+        found_layers = set()
+        for layer in self.tileset.layers:
+            layer_id = layer["layer"]['id']
+            if self.layers_ids and layer_id not in self.layers_ids:
+                continue
+            found_layers.add(layer_id)
+            # If mask-layer is set (e.g. to 'water'), add an extra column 'IsEmpty'
+            # to each layer's result row. For non-water or water in zoom <= mask-zoom,
+            # always set it to FALSE. For zoom > mask-zoom, test if the polygon spanning
+            # the entire tile is fully within layer's geometry
+            if not self.mask_layer:
+                empty_zoom = False
+            elif layer_id == self.mask_layer:
+                empty_zoom = self.mask_zoom
+            else:
+                empty_zoom = True
+            query = self.generate_layer(layer, zoom, empty_zoom, bbox)
+            queries.append(query)
+        if self.layers_ids and self.layers_ids != found_layers:
+            unknown = sorted(self.layers_ids - found_layers)
+            known = [v["layer"]['id'] for v in self.tileset.layers]
+            raise ValueError(f"Unable to find layer [{', '.join(unknown)}].\n"
+                             f"Available: [{', '.join(known)}]")
+        if not queries:
+            raise ValueError('Could not find any layer definitions')
 
+        from_clause = "FROM (\n  " + \
+                      "\n    UNION ALL\n  ".join(queries) + "\n) AS all_layers\n"
 
-def generate_sqltomvt_raw(opts):
-    return generate_query(opts, None, None)
-
-
-def generate_query(opts, bbox, zoom):
-    tileset = Tileset.parse(opts['tileset']) if isinstance(opts['tileset'], str) else opts['tileset']
-    query_tokens = {
-        'name_languages': languages_to_sql(tileset.definition.get('languages', []))
-    }
-    extent = 4096
-    pixel_width = PIXEL_SCALE
-    pixel_height = PIXEL_SCALE
-
-    queries = []
-    for layer in tileset.layers:
-        # If mask-layer is set (e.g. to 'water'), add an extra column 'IsEmpty'
-        # to each layer's result row. For non-water, or for water in zoom <= mask-zoom,
-        # always set it to FALSE. For zoom > mask-zoom, test if the polygon spanning
-        # the entire tile is fully within layer's geometry
-        if not opts['mask-layer']:
-            empty_zoom = False
-        elif layer["layer"]['id'] == opts['mask-layer']:
-            empty_zoom = opts['mask-zoom']
-        else:
-            empty_zoom = True
-        queries.append(generate_layer(layer, query_tokens, extent, empty_zoom))
-
-    from_clause = "FROM (\n  " + "\n    UNION ALL\n  ".join(queries) + "\n) AS all_layers\n"
-
-    # If mask-layer is set, wrap query to detect when the IsEmpty column is TRUE (for water),
-    # and there are no other rows, and if so, return nothing
-    if opts['mask-layer']:
-        from_clause = (
+        # If mask-layer is set, wrap query to detect when the IsEmpty column
+        # is TRUE (for water), and there are no other rows, and if so, return nothing.
+        if self.mask_layer:
+            from_clause = (
                 "FROM (\n" +
                 "SELECT IsEmpty, count(*) OVER () AS LayerCount, mvtl " +
                 from_clause +
                 ") AS counter_layers\n" +
                 "HAVING BOOL_AND(NOT IsEmpty OR LayerCount <> 1)")
 
-    query = "SELECT STRING_AGG(mvtl, '') AS mvt " + from_clause
+        query = "SELECT STRING_AGG(mvtl, '') AS mvt " + from_clause
 
-    if bbox is None:
         return query
 
-    query = (query
-             .replace("!bbox!", bbox)
-             .replace("z(!scale_denominator!)", zoom)
-             .replace("!pixel_width!", str(pixel_width))
-             .replace("!pixel_height!", str(pixel_height)))
+    def generate_layer(self, layer_def, zoom, empty_zoom, bbox):
+        """
+        If empty_zoom is True, adds an extra sql column with a constant value,
+        otherwise if it is an integer, tests if the geometry of this layer covers the whole
+        tile, and outputs true/false, otherwise no extra column is added
+        """
+        layer = layer_def["layer"]
+        query = layer['datasource']['query']
+        has_languages = '{name_languages}' in query
+        if has_languages:
+            languages = self.tileset.definition.get('languages', [])
+            query = query.format(name_languages=languages_to_sql(languages))
+        buffer = layer['buffer_size']
 
-    if '!scale_denominator!' in query:
-        raise ValueError(
-            'We made an invalid assumption that "!scale_denominator!" is always '
-            'used as a parameter to z() function. Either change the layer queries, '
-            'or fix this code')
+        if query.startswith("("):
+            # Remove the first and last parenthesis and "AS t"
+            query = query[1:query.rfind(")")]
 
-    return query
+        ext = self.extent
+        query = query.replace(
+            "geometry",
+            f"ST_AsMVTGeom(geometry, !bbox!, {ext}, {buffer}, true) AS mvtgeometry")
 
-
-def generate_layer(layer_def, query_tokens, extent, empty_zoom):
-    """
-    If empty_zoom is True, adds an extra sql column with a constant value,
-    otherwise if it is an integer, tests if the geometry of this layer covers the whole
-    tile, and outputs true/false, otherwise no extra column is added
-    """
-    layer = layer_def["layer"]
-    buffer = layer['buffer_size']
-    query = layer["datasource"]["query"].format(**query_tokens)
-
-    if query.startswith("("):
-        # Remove the first and last parenthesis and "AS t"
-        query = query[1:query.rfind(")")]
-
-    query = query.replace(
-        "geometry",
-        f"ST_AsMVTGeom(geometry, !bbox!, {extent}, {buffer}, true) AS mvtgeometry")
-
-    if isinstance(empty_zoom, bool):
-        is_empty = "FALSE AS IsEmpty, " if empty_zoom else ""
-    else:
-        # Test that geometry covers the whole tile
-        zero = 0
-        wkt_polygon = f"POLYGON(({zero} {extent},{zero} {zero},{extent} {zero},{extent} {extent},{zero} {extent}))"
-        is_empty = f"""\
-CASE z(!scale_denominator!) <= {empty_zoom} \
+        if isinstance(empty_zoom, bool):
+            is_empty = "FALSE AS IsEmpty, " if empty_zoom else ""
+        else:
+            # Test that geometry covers the whole tile
+            zero = 0
+            wkt_polygon = f"POLYGON(({zero} {ext},{zero} {zero},{ext} {zero},{ext} {ext},{zero} {ext}))"
+            is_empty = f"""\
+CASE {zoom} <= {empty_zoom} \
 WHEN TRUE THEN FALSE \
 ELSE ST_WITHIN(ST_GeomFromText('{wkt_polygon}', 3857), ST_UNION(mvtgeometry)) \
 END AS IsEmpty, """
 
-    # Combine all layer's features into a single MVT blob representing one layer
-    # only if the MVT geometry is not NULL
-    # Skip the whole layer if there is nothing in it
-    return f"""\
-SELECT {is_empty}ST_AsMVT(tile, '{layer['id']}', {extent}, 'mvtgeometry') as mvtl \
-FROM ({query} WHERE ST_AsMVTGeom(geometry, !bbox!, {extent}, {buffer}, true) IS NOT NULL) AS tile \
+        # Combine all layer's features into a single MVT blob representing one layer
+        # only if the MVT geometry is not NULL
+        # Skip the whole layer if there is nothing in it
+        query = f"""\
+SELECT {is_empty}ST_AsMVT(tile, '{layer['id']}', {ext}, 'mvtgeometry') as mvtl \
+FROM ({query} WHERE ST_AsMVTGeom(geometry, !bbox!, {ext}, {buffer}, true) IS NOT NULL) AS tile \
 HAVING COUNT(*) > 0"""
+
+        if bbox:
+            query = (query
+                     .replace("!bbox!", bbox)
+                     .replace("z(!scale_denominator!)", zoom)
+                     .replace("!pixel_width!", str(self.pixel_width))
+                     .replace("!pixel_height!", str(self.pixel_height)))
+            if '!scale_denominator!' in query:
+                raise ValueError(
+                    'MVT made an invalid assumption that "!scale_denominator!" is '
+                    'always used as a parameter to z() function. Either change '
+                    'the layer queries, or fix this code')
+        return query

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -72,6 +72,20 @@ class Layer(object):
         else:
             raise KeyError
 
+    def get_fields(self):
+        layer = self['layer']
+        datasource = layer['datasource']
+        layer_fields = list(layer['fields'].keys())
+        geo_fld = datasource['geometry'] if 'geometry' in datasource else 'geometry'
+        osm_fld = datasource['key_field'] if 'key_field' in datasource else False
+        if geo_fld in layer_fields:
+            raise ValueError(
+                f"Layer '{layer['id']}' must not have the implicit 'geometry' field "
+                f"declared in the 'fields' section of the yaml file")
+        if osm_fld:
+            layer_fields.append(osm_fld)
+        return layer_fields, geo_fld
+
 
 class Tileset(object):
     @staticmethod


### PR DESCRIPTION
A number of interrelated improvements

* consolidated language field generation in a single module
* Postserve is now capable of detecting when fields in layer metadata do not match the ones returned by the queries, and raise errors. There is still a special handling of the `{name_languages}` magic keyword, in which case the query is assumed to return all languages declared in the main layers yaml file.
* use python classes for MVT and Postserve to simplify reuse