### PR TITLE
support for generating SQL field mappings based on layer definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ layer:
           subclass: ['school','kindergarten']
         alcohol_place:
           shop: ['bar']
-          subclass: ['alcohol','beverages','wine']
+          subclass: ['alcohol','beverages','wine%']
 schema:
   - ./building.sql
 datasources:
@@ -123,7 +123,8 @@ into
 SELECT CASE
     WHEN "subclass" IN ('school', 'kindergarten') THEN 'school'
     WHEN "shop"='bar'
-        OR "subclass" IN ('alcohol','beverages','wine')
+        OR "subclass" IN ('alcohol','beverages')
+        OR "subclass" LIKE 'wine%'
         THEN 'alcohol_place'
     ELSE NULL
 END, ...

--- a/README.md
+++ b/README.md
@@ -88,11 +88,45 @@ layer:
     query: (SELECT geometry FROM layer_building(!bbox!, z(!scale_denominator!))) AS t
   fields:
     render_height: An approximated height from levels and height of building.
+    class:
+      description: Defines a subclass of a building (one of the known values).
+      # Values can be either a list of strings, or a dictionary
+      # Dictionary defines mapping of OSM values to the OMT field value
+      values:
+        school:
+          subclass: ['school','kindergarten']
+        alcohol_place:
+          shop: ['bar']
+          subclass: ['alcohol','beverages','wine']
 schema:
   - ./building.sql
 datasources:
   - type: imposm3
     mapping_file: ./mapping.yaml
+```
+
+For the well known values (enums), the `fields` section can also contain the mapping of the input (OSM) values.
+The above example has two output fields - `render_height` and `class`. The `class` field could be one of the predefined
+values. An object would have `class=school` if the OSM object has `subclass` either `school` or `kindergarten`.
+An object would have `class=alcohol_place` if it either has `shop=bar` or `subclass` having one of the 3 values.
+
+If a layer SQL files contains `%%FIELD_MAPPING: class%%`, `generate-sql` script will replace it
+
+```sql
+SELECT CASE
+    %%FIELD_MAPPING: class%%
+    ELSE NULL
+END, ...
+```
+into
+```sql
+SELECT CASE
+    WHEN "subclass" IN ('school', 'kindergarten') THEN 'school'
+    WHEN "shop"='bar'
+        OR "subclass" IN ('alcohol','beverages','wine')
+        THEN 'alcohol_place'
+    ELSE NULL
+END, ...
 ```
 
 ### Define your own Tileset

--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -97,8 +97,8 @@ def to_sql(sql, layer):
                 conditions.append(f"WHEN {cond}THEN {sql_value(map_to)}")
             else:
                 ignored.append(map_to)
-        if ignored:
-            print(f"Assuming manual SQL handling of field '{field}' values "
+        if ignored and not stderr.isatty():
+            print(f"-- Assuming manual SQL handling of field '{field}' values "
                   f"[{','.join(ignored)}] in layer {layer_def['id']}", file=stderr)
         return indent + f'\n{indent}'.join(conditions)
 

--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -1,3 +1,5 @@
+import re
+
 from .tileset import Tileset
 
 
@@ -15,7 +17,7 @@ def collect_sql(tileset_filename, parallel=False):
     parallel_sql = []
     for layer in tileset.layers:
         name = layer['layer']['id']
-        schemas = '\n\n'.join((v.strip() for v in layer.schemas))
+        schemas = '\n\n'.join((to_sql(v, layer) for v in layer.schemas))
         parallel_sql.append(f"""\
 DO $$ BEGIN RAISE NOTICE 'Processing layer {name}'; END$$;
 
@@ -46,3 +48,52 @@ RETURNS hstore AS $$
     SELECT delete_empty_keys(slice(tags, ARRAY[{tags_sql}]))
 $$ LANGUAGE SQL IMMUTABLE;
 """
+
+
+def to_sql(sql, layer):
+    """Clean up SQL, and perform any needed code injections"""
+    sql = sql.strip()
+
+    # Replace "%%FIELD_MAPPING: <fieldname>%%" with fields from layer definition
+    def field_map(match):
+        indent = match.group(1)
+        field = match.group(2)
+        fields = layer.definition['layer']['fields']
+        if field not in fields:
+            raise ValueError(f"Field '{field}' not found in the layer definition file")
+        if 'values' not in fields[field]:
+            raise ValueError(
+                f"Field '{field}' has no values defined in the layer definition file")
+        values = fields[field]['values']
+        if not isinstance(values, dict):
+            raise ValueError(f"Definition for {field}/values has to be a dictionary")
+        conditions = []
+        for map_to, mapping in values.items():
+            # mapping is a dictionary of input_fields -> (a value or a list of values)
+            whens = []
+            for in_fld, in_vals in mapping.items():
+                if isinstance(in_vals, str):
+                    in_vals = [in_vals]
+                if len(in_vals) == 1:
+                    expr = f"={sql_value(in_vals[0])}"
+                else:
+                    expr = f" IN ({', '.join((sql_value(v) for v in in_vals))})"
+                whens.append(f'{sql_field(in_fld)}{expr}')
+            cond = f'\n{indent}    OR '.join(whens) + \
+                   (' ' if len(whens) == 1 else f'\n{indent}    ')
+            conditions.append(f"WHEN {cond}THEN {sql_value(map_to)}")
+        return indent + f'\n{indent}'.join(conditions)
+
+    sql = re.sub(r'( *)%%\s*FIELD_MAPPING\s*:\s*([a-zA-Z0-9_-]+)\s*%%', field_map, sql)
+
+    return sql
+
+
+def sql_field(field):
+    return f'"{field}"'
+
+
+def sql_value(value):
+    if "'" not in value:
+        return f"'{value}'"
+    return "E'" + value.replace('\\', '\\\\').replace("'", "\\'") + "'"

--- a/testdata/expected/mvttile_func.sql
+++ b/testdata/expected/mvttile_func.sql
@@ -2,6 +2,8 @@ CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS bytea AS $$
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
   SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom) WHERE ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_prep.sql
+++ b/testdata/expected/mvttile_prep.sql
@@ -9,5 +9,7 @@ END $$;
 PREPARE gettile(integer, integer, integer) AS
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
   SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 ;

--- a/testdata/expected/mvttile_psql.sql
+++ b/testdata/expected/mvttile_psql.sql
@@ -1,4 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
   SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom) WHERE ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query.sql
+++ b/testdata/expected/mvttile_query.sql
@@ -1,4 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
   SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query_zd.sql
+++ b/testdata/expected/mvttile_query_zd.sql
@@ -1,6 +1,8 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
 SELECT IsEmpty, count(*) OVER () AS LayerCount, mvtl FROM (
   SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 ) AS counter_layers
 HAVING BOOL_AND(NOT IsEmpty OR LayerCount <> 1)

--- a/testdata/expected/mvttile_query_zd2.sql
+++ b/testdata/expected/mvttile_query_zd2.sql
@@ -1,6 +1,8 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
 SELECT IsEmpty, count(*) OVER () AS LayerCount, mvtl FROM (
   SELECT CASE $1 <= 8 WHEN TRUE THEN FALSE ELSE ST_WITHIN(ST_GeomFromText('POLYGON((0 4096,0 0,4096 0,4096 4096,0 4096))', 3857), ST_UNION(mvtgeometry)) END AS IsEmpty, ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+    UNION ALL
+  SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
 ) AS all_layers
 ) AS counter_layers
 HAVING BOOL_AND(NOT IsEmpty OR LayerCount <> 1)

--- a/testdata/expected/parallel_sql/parallel/001.sql
+++ b/testdata/expected/parallel_sql/parallel/001.sql
@@ -1,0 +1,13 @@
+DO $$ BEGIN RAISE NOTICE 'Processing layer enumfield'; END$$;
+
+CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN "natural"='bare_rock' THEN 'rock'
+        WHEN "natural"='grassland'
+            OR "landuse" IN ('grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            THEN 'grass'
+        ELSE NULL
+END;
+$$ LANGUAGE SQL IMMUTABLE;
+
+DO $$ BEGIN RAISE NOTICE 'Finished layer enumfield'; END$$;

--- a/testdata/expected/parallel_sql/parallel/001.sql
+++ b/testdata/expected/parallel_sql/parallel/001.sql
@@ -4,7 +4,8 @@ CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR)
     SELECT CASE
         WHEN "natural"='bare_rock' THEN 'rock'
         WHEN "natural"='grassland'
-            OR "landuse" IN ('grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            OR "landuse" IN ('grass', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            OR "landuse" LIKE 'meadow%'
             THEN 'grass'
         ELSE NULL
 END;

--- a/testdata/expected/sql.sql
+++ b/testdata/expected/sql.sql
@@ -20,3 +20,17 @@ $$ LANGUAGE SQL IMMUTABLE;
 
 DO $$ BEGIN RAISE NOTICE 'Finished layer housenumber'; END$$;
 
+DO $$ BEGIN RAISE NOTICE 'Processing layer enumfield'; END$$;
+
+CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN "natural"='bare_rock' THEN 'rock'
+        WHEN "natural"='grassland'
+            OR "landuse" IN ('grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            THEN 'grass'
+        ELSE NULL
+END;
+$$ LANGUAGE SQL IMMUTABLE;
+
+DO $$ BEGIN RAISE NOTICE 'Finished layer enumfield'; END$$;
+

--- a/testdata/expected/sql.sql
+++ b/testdata/expected/sql.sql
@@ -26,7 +26,8 @@ CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR)
     SELECT CASE
         WHEN "natural"='bare_rock' THEN 'rock'
         WHEN "natural"='grassland'
-            OR "landuse" IN ('grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            OR "landuse" IN ('grass', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
+            OR "landuse" LIKE 'meadow%'
             THEN 'grass'
         ELSE NULL
 END;

--- a/testdata/expected/tm2source.yml
+++ b/testdata/expected/tm2source.yml
@@ -26,6 +26,29 @@ Layer:
     buffer-size: 8
   srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0
     +units=m +nadgrids=@null +wktext +no_defs +over
+- Datasource:
+    dbname: pgdb
+    extent:
+    - -20037508.34
+    - -20037508.34
+    - 20037508.34
+    - 20037508.34
+    geometry_field: geometry
+    host: pghost
+    key_field: ''
+    key_field_as_attribute: ''
+    max_size: 512
+    password: pgpswd
+    port: 5432
+    srid: 900913
+    table: ''
+    type: postgis
+    user: pguser
+  id: enumfield
+  properties:
+    buffer-size: 0
+  srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0
+    +units=m +nadgrids=@null +wktext +no_defs +over
 attribution: <a href="http://www.openstreetmap.org/about/" target="_blank">&copy;
   OpenStreetMap contributors</a>
 bounds:

--- a/testdata/testlayers/enumfield/enumfield.sql
+++ b/testdata/testlayers/enumfield/enumfield.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
+    SELECT CASE
+        %%FIELD_MAPPING: class %%
+        ELSE NULL
+END;
+$$ LANGUAGE SQL IMMUTABLE;

--- a/testdata/testlayers/enumfield/enumfield.yaml
+++ b/testdata/testlayers/enumfield/enumfield.yaml
@@ -1,0 +1,20 @@
+layer:
+  id: enumfield
+  description: |
+    Test for converting enumfields
+  buffer_size: 0
+  fields:
+    class:
+      description: |
+        test field
+      values:
+        rock:
+          natural: ['bare_rock']
+        grass:
+          natural: 'grassland'
+          landuse: ['grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground']
+  datasource:
+    query: ''
+schema:
+  - ./enumfield.sql
+datasources: []

--- a/testdata/testlayers/enumfield/enumfield.yaml
+++ b/testdata/testlayers/enumfield/enumfield.yaml
@@ -12,7 +12,11 @@ layer:
           natural: ['bare_rock']
         grass:
           natural: 'grassland'
-          landuse: ['grass', 'meadow', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground']
+          # Anything with % should use 'LIKE' instead of equality
+          landuse: ['grass', 'meadow%', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground']
+        # These options are not auto-generated
+        other1: {}
+        other2: false
   datasource:
     query: ''
 schema:

--- a/testdata/testlayers/testmaptiles.yaml
+++ b/testdata/testlayers/testmaptiles.yaml
@@ -1,6 +1,7 @@
 tileset:
   layers:
     - housenumber/housenumber.yaml
+    - enumfield/enumfield.yaml
   name: TestMapTiles v1.0
   description: "Simple tileset for testing."
   attribution: "<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap contributors</a>"


### PR DESCRIPTION
see README

Allows auto-replacement of SQL's

```sql
SELECT CASE
    %%FIELD_MAPPING: class%%
    ELSE NULL
END, ...
```

with

```sql
SELECT CASE
    WHEN "subclass" IN ('school', 'kindergarten') THEN 'school'
    WHEN "shop"='bar'
        OR "subclass" IN ('alcohol','beverages','wine')
        THEN 'alcohol_place'
    ELSE NULL
END, ...
```

This PR is required for https://github.com/openmaptiles/openmaptiles/pull/693/files