### PR TITLE
refresh materialized views in parallel utility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,11 +2,13 @@
 .git/
 .gitignore
 .travis.yml
+build/
 docker-run.sh
 Dockerfile
 Makefile
-testdata/
 setup.py
+testdata/
+tests/
 
 #
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 WORKDIR /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ test: clean build-tests
 	@echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 	@echo "   Comparing built results with the expected ones"
 	@echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-
 	$(DIFF_CMD) build $(EXPECTED_DIR)
-
+	@echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+	@echo "   Running Python unit tests"
+	@echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+	$(RUN_CMD) python -m unittest
 	@echo "<<<<<<<<<<<<<<<<<<<<< SUCCESS <<<<<<<<<<<<<<<<<<<<<"
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -258,3 +258,6 @@ generate-sqltomvt openmaptiles.yaml > "$SQL_DIR/mvt.sql" && import_sql.sh
 
 Optionally you may pass extra arguments to `psql` by using `PSQL_OPTIONS` environment variable. For example `PSQL_OPTIONS=-a` makes psql echo all commands read from a file into stdout.
 `PSQL_OPTIONS` allows multiple arguments as well, and understands quotes, e.g. you can pass a whole query as a single argument surrounded by quotes -- `PSQL_OPTIONS="-a -c 'SELECT ...'"`
+
+### Performance optimizations
+Materialized views can be refreshed in parallel using `run-sql refresh-views` command. This could be especially useful if the `CREATE MATERIALIZED VIEW` statements had `WITH NO DATA` clause.

--- a/bin/run-sql
+++ b/bin/run-sql
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+"""
+Refresh all PostgreSQL materialized views in parallel, taking into account cross-dependencies.
+
+Usage:
+  run-sql refresh-views [--parallel=<count>] [--schema=<schema>]
+          [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+          [--user=<user>] [--password=<password>] [--verbose]
+  run-sql --help
+  run-sql --version
+
+Options:
+  -p --parallel=<count> Run up to this many parallel queries at the same time  [default: 4].
+  -s --schema=<schema>  Limit refreshes to a single schema.
+  -h --pghost=<host>    Postgres hostname. By default uses PGHOST env or "localhost" if not set.
+  -P --pgport=<port>    Postgres port. By default uses PGPORT env or "5432" if not set.
+  -d --dbname=<db>      Postgres db name. By default uses PGDATABASE env or "openmaptiles" if not set.
+  -U --user=<user>      Postgres user. By default uses PGUSER env or "openmaptiles" if not set.
+  --password=<password> Postgres password. By default uses PGPASSWORD env or "openmaptiles" if not set.
+  -v --verbose          Print additional debugging information.
+  --help                Show this screen.
+  --version             Show version.
+
+  These legacy env vars should not be used, but they are still supported:
+     POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
+"""
+import asyncio
+import os.path
+from collections import defaultdict
+from datetime import datetime
+from typing import List
+
+import asyncpg
+from docopt import docopt
+
+import openmaptiles
+from openmaptiles.utils import Action, run_actions
+from openmaptiles.utils import coalesce
+
+
+def main(args):
+    asyncio.run(async_main(
+        max_queries=int(args['--parallel']),
+        schema=args['--schema'],
+        pghost=coalesce(
+            args.get("--pghost"), os.getenv('POSTGRES_HOST'), os.getenv('PGHOST'),
+            'localhost'),
+        pgport=coalesce(
+            args.get("--pgport"), os.getenv('POSTGRES_PORT'), os.getenv('PGPORT'),
+            '5432'),
+        dbname=coalesce(
+            args.get("--dbname"), os.getenv('POSTGRES_DB'), os.getenv('PGDATABASE'),
+            'openmaptiles'),
+        user=coalesce(
+            args.get("--user"), os.getenv('POSTGRES_USER'), os.getenv('PGUSER'),
+            'openmaptiles'),
+        password=coalesce(
+            args.get("--password"), os.getenv('POSTGRES_PASSWORD'),
+            os.getenv('PGPASSWORD'), 'openmaptiles'),
+        verbose=args.get('--verbose'),
+    ))
+
+
+# This query gets all PostgreSQL object cross-dependencies.
+# Later on, we only refresh materialized views, but we need all types of objects
+# because in theory a materialized view could depend on a function that itself
+# depends on two other materialized views.
+# This query also includes any materialized views that do not depend on anything.
+SQL_GET_MATERIALIZED_VIEWS = """\
+WITH objects AS (
+    SELECT distinct
+        c2.oid AS oid,
+        n2.nspname AS objSchema,
+        c2.relname AS name,
+        c2.relkind AS type,
+        n.nspname AS dependsOnSchema,
+        c.relname AS dependsOnName,
+        c.relkind AS dependsOnType
+    FROM
+        pg_class c
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+        JOIN pg_depend d ON d.refobjid=c.oid
+        JOIN pg_rewrite r ON r.oid=d.objid
+        JOIN pg_class c2 ON c2.oid=r.ev_class AND c2.oid != c.oid
+        JOIN pg_namespace n2 ON c2.relnamespace=n2.oid
+        JOIN pg_authid au ON au.oid=c2.relowner
+    WHERE c.relkind IN ('r','m','v','t','f')
+)
+(
+    -- all objects with all of their dependencies
+    SELECT * FROM objects
+UNION ALL
+    -- any materialized views that have no dependencies
+    SELECT
+        c.oid AS oid, n.nspname AS objSchema, c.relname AS name, c.relkind AS type,
+        NULL AS dependsOnSchema, NULL AS dependsOnName, NULL AS dependsOnType
+    FROM
+        pg_class c
+        JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE c.relkind = 'm' AND c.oid not in (select o.oid from objects o)
+) order by objSchema, name, dependsOnSchema, dependsOnName
+"""
+
+
+async def async_main(schema, dbname, pghost, pgport, user, password, max_queries,
+                     verbose):
+    print(f'Connecting to PostgreSQL at {pghost}:{pgport}, db={dbname}, user={user}...')
+    async with asyncpg.create_pool(
+        database=dbname, host=pghost, port=pgport, user=user, password=password,
+        min_size=1, max_size=max_queries,
+    ) as pool:
+        print(f"Loading all materialized views from {dbname}...")
+        rows = defaultdict(list)
+        for row in await pool.fetch(SQL_GET_MATERIALIZED_VIEWS):
+            depends_on = None
+            if row['dependsonschema']:
+                depends_on = f"{row['dependsonschema']}.{row['dependsonname']}"
+            obj_id = (row['objschema'], row['name'], row['type'] == b'm')
+            rows[obj_id].append(depends_on)
+
+        actions = [Query(
+            action_id=f"{obj_id[0]}.{obj_id[1]}",
+            depends_on=[v for v in dependencies if v],
+            query=(None if not obj_id[2] or (schema and obj_id[0] != schema) else
+                   f"REFRESH MATERIALIZED VIEW {obj_id[0]}.{obj_id[1]};")
+        ) for obj_id, dependencies in rows.items()]
+
+        async def executor(action: Query, _: List):
+            if not action.query:
+                return  # Actions without queries are treated as awaitable placeholders
+            info = f"{datetime.utcnow()} refreshing  {action.action_id}"
+            if action.depends_on:
+                info += f"  because  {', '.join(action.depends_on)}  finished."
+            print(info)
+            await pool.execute(action.query)
+            print(f"{datetime.utcnow()} finished refreshing  {action.action_id}.")
+
+        print(f"Refreshing {sum((1 for v in actions if v.query))} materialized views"
+              f"{f' in schema {schema}' if schema else ''}...")
+        await run_actions(actions, executor, ignore_unknown=True, verbose=verbose)
+
+
+class Query(Action):
+    def __init__(self, action_id: str, query: str, depends_on: List[str] = None):
+        super().__init__(action_id, depends_on)
+        self.query = query
+
+
+if __name__ == '__main__':
+    main(docopt(__doc__, version=openmaptiles.__version__))

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 set -e
 
-: ${VERSION:=$(cat VERSION)}
-: ${IMAGE_NAME:=openmaptiles/openmaptiles-tools}
-: ${DOCKER_IMAGE:=${IMAGE_NAME}:${VERSION}}
-: ${DOCKER_USER:=$(id -u ${USER}):$(id -g ${USER})}
+: "${VERSION:=$(cat "$(dirname "$0")/VERSION")}"
+: "${IMAGE_NAME:=openmaptiles/openmaptiles-tools}"
+: "${DOCKER_IMAGE:=${IMAGE_NAME}:${VERSION}}"
+: "${DOCKER_USER:=$(id -u "${USER}"):$(id -g "${USER}")}"
 
 # Current dir is shared with the docker, allowing scripts to write to the dir as a current user
-: ${WORKDIR:="$( pwd -P )"}
+: "${WORKDIR:="$( pwd -P )"}"
 
 if [[ -t 1 ]]; then
   # Running in a terminal
-  : ${DOCKER_OPTS:="-it --rm"}
+  : "${DOCKER_OPTS:="-it --rm"}"
 else
-  : ${DOCKER_OPTS:="--rm"}
+  : "${DOCKER_OPTS:="--rm"}"
 fi
 
 set -x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 ## This list is also used by setup.py - install_requires
 ## But there it removes all version restrictions
-docopt==0.6.2
-pyyaml==5.1.2
-graphviz==0.11.1
-tornado==6.0.3
 asyncpg==0.19.0
+docopt==0.6.2
+graphviz==0.11.1
+psycopg2-binary==2.8.3
+pyyaml==5.1.2
+tornado==6.0.3

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,30 @@
+from asyncio import sleep
+from unittest import IsolatedAsyncioTestCase, main
+from openmaptiles.utils import Action, run_actions
+
+
+class UtilsTestCase(IsolatedAsyncioTestCase):
+    async def test_response(self):
+        async def executor(action, dependencies):
+            self.assertEqual(dependencies, action.depends_on)
+            await sleep(float(action.action_id[1:]) / 200)
+            return action.action_id
+
+        async def test(**actions):
+            res = await run_actions(
+                [Action(k, depends_on=v) for k, v in actions.items()],
+                executor
+            )
+            self.assertEqual(res, list(actions.keys()))
+
+        await test()
+        await test(a1=None)
+        await test(a1=[], a2=['a1'])
+        await test(a1=['a2'], a2=None)
+        await test(a1=['a2'], a2=[])
+        await test(a1=[], a2=[], a3=['a1', 'a2'])
+        await test(a1=[], a2=[], a3=['a1'], a4=['a1', 'a3'], a5=['a2', 'a4'])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Materialized views can be refreshed in parallel using `run-sql refresh-views` command.
This could be especially useful if the `CREATE MATERIALIZED VIEW` statements had `WITH NO DATA` clause.

* Added automated unit testing for python script.
* Python docker was bumped to 3.8 to simplify unit testing,
but scripts would still run on 3.7 (or even lower Python versions).
* Minor cleanup of the `docker-run.sh` script