### PR TITLE
Removed mask-layer support, simplified MVT generation (faster)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ build-tests: \
     build/mvttile_psql.sql \
     build/mvttile_prep.sql \
     build/mvttile_query.sql \
-    build/mvttile_query_zd.sql \
-    build/mvttile_query_zd2.sql \
     build/doc/doc.md \
     build/sqlquery.sql \
     build/devdoc

--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,6 @@ build/mvttile_prep.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --prepared                           > build/mvttile_prep.sql
 build/mvttile_query.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query                              > build/mvttile_query.sql
-build/mvttile_query_zd.sql: prepare
-	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --mask-layer=water           > build/mvttile_query_zd.sql
-build/mvttile_query_zd2.sql: prepare
-	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --mask-layer=housenumber     > build/mvttile_query_zd2.sql
 build/doc/doc.md: prepare
 	$(RUN_CMD) generate-doc      testdata/testlayers/housenumber/housenumber.yaml                           > build/doc.md
 build/sqlquery.sql: prepare

--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -7,7 +7,6 @@ Usage:
   generate-sqltomvt <tileset> [--fname <name>]
                     [--function | --prepared | --query | --psql | --raw]
                     [--layer=<layer>]...
-                    [--mask-layer=<layer> --mask-zoom=<z>]
   generate-sqltomvt --help
   generate-sqltomvt --version
 
@@ -20,9 +19,6 @@ Options:
   -d --psql              Generate a query SQL with :zoom,:x,:y vars to simplify PSQL debugging with  \set zoom 5
   -r --raw               Generate raw query without any wrappers (good for debugging SQL)
   -l --layer=<layer>     If set, limit tile generation to just this layer (could be multiple)
-  --mask-layer=<layer>   If tile only has this layer covering for the whole tile (e.g. 'water'),
-                         and requested zoom is more than --mask-zoom parameter, returns empty result
-  --mask-zoom=<z>        If --mask-layer is set, tiles will be checked for empty after given zoom  [default: 8]
   --fname=<name>         Name of the generated function  [default: gettile]
   --help                 Show this screen.
   --version              Show version.
@@ -35,8 +31,6 @@ if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
     mvt = MvtGenerator(
         tileset=args['<tileset>'],
-        mask_layer=args['--mask-layer'],
-        mask_zoom=int(args['--mask-zoom']),
         layer_ids=args['--layer'],
     )
 

--- a/bin/postserve
+++ b/bin/postserve
@@ -5,7 +5,6 @@ This is a simple vector tile server that returns a PBF tile for  /tiles/{z}/{x}/
 Usage:
   postserve <tileset> [--serve=<host>] [--port=<port>]
                       [--file=<sql-file>] [--layer=<layer>]... [--verbose]
-                      [--mask-layer=<layer> --mask-zoom=<z>]
                       [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
                       [--user=<user>] [--password=<password>]
   postserve --help
@@ -15,9 +14,6 @@ Usage:
 
 Options:
   -l --layer=<layer>    If set, limit tile generation to just this layer (could be multiple)
-  --mask-layer=<layer>  If tile only has this layer covering for the whole tile (e.g. 'water'),
-                        and requested zoom is more than --mask-zoom parameter, returns empty result
-  --mask-zoom=<z>       If --mask-layer is set, tiles will be checked for empty after given zoom  [default: 8]
   -s --serve=<port>     Return this hostname as tileserver URL in metadata  [default: localhost]
   -p --port=<port>      Serve on this port  [default: 8090]
   -v --verbose          Print additional debugging information
@@ -63,12 +59,6 @@ if __name__ == '__main__':
         tilejson="2.0.0",
     )
 
-    mask_zoom = None
-    mask_layer = args['--mask-layer']
-    if mask_layer:
-        mask_zoom = int(args['--mask-zoom'])
-        metadata['maskLevel'] = mask_zoom
-
     Postserve(
         host=args['--serve'],
         port=int(args['--port']),
@@ -91,7 +81,5 @@ if __name__ == '__main__':
         layers=args['--layer'],
         tileset_path=args['<tileset>'],
         sql_file=args.get('--file'),
-        mask_layer=mask_layer,
-        mask_zoom=mask_zoom,
         verbose=args.get('--verbose'),
     ).serve()

--- a/openmaptiles/postserve.py
+++ b/openmaptiles/postserve.py
@@ -86,7 +86,7 @@ class Postserve:
     pool: Pool
 
     def __init__(self, host, port, pghost, pgport, dbname, user, password, metadata,
-                 layers, tileset_path, sql_file, mask_layer, mask_zoom, verbose):
+                 layers, tileset_path, sql_file, verbose):
         self.host = host
         self.port = port
         self.pghost = pghost
@@ -100,7 +100,7 @@ class Postserve:
         self.verbose = verbose
 
         self.tileset = Tileset.parse(self.tileset_path)
-        self.mvt = MvtGenerator(self.tileset, mask_layer, mask_zoom, layers)
+        self.mvt = MvtGenerator(self.tileset, layers)
 
     async def generate_metadata(self):
         self.metadata["tiles"] = [

--- a/testdata/expected/mvttile_func.sql
+++ b/testdata/expected/mvttile_func.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS bytea AS $$
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom) WHERE ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
     UNION ALL
-  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
 ) AS all_layers
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_prep.sql
+++ b/testdata/expected/mvttile_prep.sql
@@ -8,8 +8,8 @@ END $$;
 -- Run this statement with   EXECUTE gettile(zoom, x, y)
 PREPARE gettile(integer, integer, integer) AS
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 ;

--- a/testdata/expected/mvttile_psql.sql
+++ b/testdata/expected/mvttile_psql.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom) WHERE ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom)) AS t
     UNION ALL
-  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(:zoom, :x, :y), :zoom)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query.sql
+++ b/testdata/expected/mvttile_query.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query_zd.sql
+++ b/testdata/expected/mvttile_query_zd.sql
@@ -1,8 +1,0 @@
-SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-SELECT IsEmpty, count(*) OVER () AS LayerCount, mvtl FROM (
-  SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
-    UNION ALL
-  SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
-) AS all_layers
-) AS counter_layers
-HAVING BOOL_AND(NOT IsEmpty OR LayerCount <> 1)

--- a/testdata/expected/mvttile_query_zd2.sql
+++ b/testdata/expected/mvttile_query_zd2.sql
@@ -1,8 +1,0 @@
-SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-SELECT IsEmpty, count(*) OVER () AS LayerCount, mvtl FROM (
-  SELECT CASE $1 <= 8 WHEN TRUE THEN FALSE ELSE ST_WITHIN(ST_GeomFromText('POLYGON((0 4096,0 0,4096 0,4096 4096,0 4096))', 3857), ST_UNION(mvtgeometry)) END AS IsEmpty, ST_AsMVT(tile, 'housenumber', 4096, 'mvtgeometry') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1) WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
-    UNION ALL
-  SELECT FALSE AS IsEmpty, ST_AsMVT(tile, 'enumfield', 4096, 'mvtgeometry') as mvtl FROM ( WHERE ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) IS NOT NULL) AS tile HAVING COUNT(*) > 0
-) AS all_layers
-) AS counter_layers
-HAVING BOOL_AND(NOT IsEmpty OR LayerCount <> 1)

--- a/testdata/expected/tm2source.yml
+++ b/testdata/expected/tm2source.yml
@@ -41,7 +41,8 @@ Layer:
     password: pgpswd
     port: 5432
     srid: 900913
-    table: ''
+    table: (SELECT geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!)))
+      AS t
     type: postgis
     user: pguser
   id: enumfield

--- a/testdata/testlayers/enumfield/enumfield.yaml
+++ b/testdata/testlayers/enumfield/enumfield.yaml
@@ -18,7 +18,9 @@ layer:
         other1: {}
         other2: false
   datasource:
-    query: ''
+    geometry_field: geometry
+    srid: 900913
+    query: (SELECT geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./enumfield.sql
 datasources: []


### PR DESCRIPTION
* Removed --mask-layer and --mask-zoom params from postserve and
  generate-sqltomvt -- it never worked properly, because it generated
  identical results for the empty land and for the empty water.
  Need to rethink this strategy for the future, but for now removing.
* queries are now ~15% faster

Running with `--summary --minzoom 5 --test-all`
Generated 17,646 tiles in 0:03:22.8, 87.0 tiles/s +15.6%, 5,214.0 bytes/tile -0.0%