### PR TITLE
Use key_field as ST_AsMVT(...,feature_id_name)

### DIFF
--- a/openmaptiles/sqltomvt.py
+++ b/openmaptiles/sqltomvt.py
@@ -108,7 +108,8 @@ PREPARE {fname}(integer, integer, integer) AS
         # Skip the whole layer if there is nothing in it
         query = f"""\
 SELECT \
-COALESCE(ST_AsMVT(t, '{layer['id']}', {ext}, 'mvtgeometry', {key_fld or 'NULL'}), '') \
+COALESCE(ST_AsMVT(t, '{layer['id']}', {ext}, 'mvtgeometry'\
+{f", '{key_fld}'" if key_fld else ""}), '') \
 as mvtl \
 FROM {repl_query}"""
 

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -74,17 +74,22 @@ class Layer(object):
 
     def get_fields(self):
         layer = self['layer']
-        datasource = layer['datasource']
+        source = layer['datasource']
         layer_fields = list(layer['fields'].keys())
-        geo_fld = datasource['geometry'] if 'geometry' in datasource else 'geometry'
-        osm_fld = datasource['key_field'] if 'key_field' in datasource else False
+        geo_fld = source['geometry'] if 'geometry' in source else 'geometry'
+        key_field = source['key_field'] if 'key_field' in source else False
         if geo_fld in layer_fields:
             raise ValueError(
                 f"Layer '{layer['id']}' must not have the implicit 'geometry' field "
                 f"declared in the 'fields' section of the yaml file")
-        if osm_fld:
-            layer_fields.append(osm_fld)
-        return layer_fields, geo_fld
+        if key_field:
+            layer_fields.append(key_field)
+            if source.get('key_field_as_attribute') and \
+                source['key_field_as_attribute'] != 'no':
+                # If 'yes', we will need to generate a wrapper query that includes
+                # osm_id column twice - once for feature_id, and once as an attribute
+                raise ValueError('key_field_as_attribute=yes is not yet implemented')
+        return layer_fields, geo_fld, key_field
 
 
 class Tileset(object):

--- a/testdata/expected/mvttile_func.sql
+++ b/testdata/expected/mvttile_func.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS bytea AS $$
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
 ) AS all_layers
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_func.sql
+++ b/testdata/expected/mvttile_func.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS bytea AS $$
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
 ) AS all_layers
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_func_key.sql
+++ b/testdata/expected/mvttile_func_key.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS TABLE(mvt bytea, key text) AS $$
 SELECT mvt, md5(mvt) AS key FROM (SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
 ) AS all_layers) AS mvt_data
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_func_key.sql
+++ b/testdata/expected/mvttile_func_key.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION gettile(zoom integer, x integer, y integer)
 RETURNS TABLE(mvt bytea, key text) AS $$
 SELECT mvt, md5(mvt) AS key FROM (SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(zoom, x, y), zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(zoom, x, y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(zoom, x, y), zoom)) AS t
 ) AS all_layers) AS mvt_data
 ;
 $$ LANGUAGE SQL STABLE RETURNS NULL ON NULL INPUT;

--- a/testdata/expected/mvttile_prep.sql
+++ b/testdata/expected/mvttile_prep.sql
@@ -8,8 +8,8 @@ END $$;
 -- Run this statement with   EXECUTE gettile(zoom, x, y)
 PREPARE gettile(integer, integer, integer) AS
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 ;

--- a/testdata/expected/mvttile_prep.sql
+++ b/testdata/expected/mvttile_prep.sql
@@ -8,8 +8,8 @@ END $$;
 -- Run this statement with   EXECUTE gettile(zoom, x, y)
 PREPARE gettile(integer, integer, integer) AS
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 ;

--- a/testdata/expected/mvttile_psql.sql
+++ b/testdata/expected/mvttile_psql.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(:zoom, :x, :y), :zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(:zoom, :x, :y), :zoom)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_psql.sql
+++ b/testdata/expected/mvttile_psql.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox(:zoom, :x, :y), :zoom)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(:zoom, :x, :y), :zoom)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox(:zoom, :x, :y), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox(:zoom, :x, :y), :zoom)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query.sql
+++ b/testdata/expected/mvttile_query.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query.sql
+++ b/testdata/expected/mvttile_query.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
-  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(TileBBox($1, $2, $3), $1)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', NULL), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 

--- a/testdata/expected/tm2source.yml
+++ b/testdata/expected/tm2source.yml
@@ -35,13 +35,13 @@ Layer:
     - 20037508.34
     geometry_field: geometry
     host: pghost
-    key_field: ''
-    key_field_as_attribute: ''
+    key_field: osm_id
+    key_field_as_attribute: false
     max_size: 512
     password: pgpswd
     port: 5432
     srid: 900913
-    table: (SELECT geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!)))
+    table: (SELECT osm_id, geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!)))
       AS t
     type: postgis
     user: pguser

--- a/testdata/testlayers/enumfield/enumfield.yaml
+++ b/testdata/testlayers/enumfield/enumfield.yaml
@@ -19,8 +19,10 @@ layer:
         other2: false
   datasource:
     geometry_field: geometry
+    key_field: osm_id
+    key_field_as_attribute: no
     srid: 900913
-    query: (SELECT geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT osm_id, geometry, enumfield FROM layer_enumfields(!bbox!, z(!scale_denominator!))) AS t
 schema:
   - ./enumfield.sql
 datasources: []


### PR DESCRIPTION
key_field (usually "osm_id") is now included as
the 5th parameter of ST_AsMVT() - feature_id_name

Note that if we ever want to include osm_id
as both an ID and a regular attribute, we will need to add
support for that.