### PR TITLE
Reworked to shrink Lakelikens docker img, env vars

### DIFF
--- a/docker/import-lakelines/.dockerignore
+++ b/docker/import-lakelines/.dockerignore
@@ -1,1 +1,2 @@
 .git
+Dockerfile

--- a/docker/import-lakelines/Dockerfile
+++ b/docker/import-lakelines/Dockerfile
@@ -1,9 +1,10 @@
 # Use a separate docker for downloading to minimize final docker image
-FROM appropriate/curl as downloader
-RUN cd / && \
-    curl --compressed -OL https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
+FROM openmaptiles/openmaptiles-tools:0.12.0 as downloader
+WORKDIR /
+RUN wget --quiet -L https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
 
-FROM osgeo/gdal:alpine-small-3.0.2
+
+FROM osgeo/gdal:alpine-normal-3.0.2
 ENV IMPORT_DIR=/import \
     LAKELINES_GEOJSON=/data/import/lake_centerline.geojson
 

--- a/docker/import-lakelines/Dockerfile
+++ b/docker/import-lakelines/Dockerfile
@@ -1,18 +1,13 @@
-FROM openmaptiles/postgis:2.9
+# Use a separate docker for downloading to minimize final docker image
+FROM appropriate/curl as downloader
+RUN cd / && \
+    curl --compressed -OL https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
 
+FROM osgeo/gdal:alpine-small-3.0.2
 ENV IMPORT_DIR=/import \
     LAKELINES_GEOJSON=/data/import/lake_centerline.geojson
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      wget \
-      ca-certificates \
-    && wget --quiet -L -P "$IMPORT_DIR" https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson \
-    && apt-get purge -y --auto-remove \
-      wget \
-      ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
+COPY --from=downloader /lake_centerline.geojson $IMPORT_DIR/
 WORKDIR /usr/src/app
-
 COPY . /usr/src/app
 CMD ["./import_lakelines.sh"]

--- a/docker/import-lakelines/README.md
+++ b/docker/import-lakelines/README.md
@@ -7,10 +7,17 @@ Provide the database credentials and run `import-lakelines`.
 
 ```bash
 docker run --rm \
-    -e POSTGRES_USER="osm" \
-    -e POSTGRES_PASSWORD="osm" \
-    -e POSTGRES_HOST="127.0.0.1" \
-    -e POSTGRES_DB="osm" \
-    -e POSTGRES_PORT="5432" \
+    -e PGHOST="127.0.0.1" \
+    -e PGDATABASE="openmaptiles" \
+    -e PGUSER="openmaptiles" \
+    -e PGPASSWORD="openmaptiles" \
     openmaptiles/import-lakelines
 ```
+
+Optional environment variables:
+* `PGPORT` (defaults to `5432`)
+* `LAKE_CENTERLINE_TABLE` (defaults to `lake_centerline`)
+* `PGCONN` - Postgres connection string to override all previous env vars
+
+Legacy env variables are still supported, but they are not recommended:
+`POSTGRES_HOST`,`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT`

--- a/docker/import-lakelines/import_lakelines.sh
+++ b/docker/import-lakelines/import_lakelines.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -o errexit
-set -o pipefail
 set -o nounset
 
 LAKE_CENTERLINE_TABLE="${LAKE_CENTERLINE_TABLE:-lake_centerline}"
@@ -16,10 +15,14 @@ PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
 
 PGCONN="${PGCONN:-dbname=$PGDATABASE user=$PGUSER host=$PGHOST password=$PGPASSWORD port=$PGPORT}"
 
+echo "Importing lake lines into PostgreSQL"
 PGCLIENTENCODING=UTF8 ogr2ogr \
-    -f Postgresql \
-    -s_srs EPSG:4326 \
-    -t_srs EPSG:3857 \
-    PG:"$PGCONN" \
-    "$IMPORT_DIR/lake_centerline.geojson" \
-    -nln "$LAKE_CENTERLINE_TABLE"
+  -progress \
+  -f Postgresql \
+  -s_srs EPSG:4326 \
+  -t_srs EPSG:3857 \
+  PG:"${PGCONN?}" \
+  -lco OVERWRITE=YES \
+  -overwrite \
+  -nln "${LAKE_CENTERLINE_TABLE?}" \
+  "$IMPORT_DIR/lake_centerline.geojson"


### PR DESCRIPTION
Functionality change:
Added `-lco OVERWRITE=YES -overwrite` parameters to `ogr2ogr`
this makes import much faster, and ensures that the centerline table is dropped before the import begins.

Other changes:
* docker image is now based on osgeo/gdal:alpine-small-3.0.2
* lake_centerline.geojson is downloaded in a separate image
* script is now using standard PG* env vars for PostgreSQL access
* LAKE_CENTERLINE_TABLE is now configurable
* can override PGCONN
