### PR TITLE
Shrink docker NaturalEarth img, env vars, latest ogr2ogr

### DIFF
--- a/imports/natural-earth/.dockerignore
+++ b/imports/natural-earth/.dockerignore
@@ -1,1 +1,2 @@
 .git
+Dockerfile

--- a/imports/natural-earth/Dockerfile
+++ b/imports/natural-earth/Dockerfile
@@ -1,24 +1,20 @@
-FROM openmaptiles/postgis:2.9
-MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
+# Use a separate docker for downloading to minimize final docker image
+FROM openmaptiles/openmaptiles-tools:0.12.0 as downloader
+WORKDIR /usr/src/app-ne
+COPY clean-natural-earth.sh .
+RUN wget --quiet http://naciscdn.org/naturalearth/packages/natural_earth_vector.sqlite.zip && \
+    unzip -oj natural_earth_vector.sqlite.zip -d . '*natural_earth_vector.sqlite' && \
+    NATURAL_EARTH_DB=./natural_earth_vector.sqlite ./clean-natural-earth.sh
+
+
+FROM osgeo/gdal:alpine-normal-3.0.2
+MAINTAINER "Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
 ENV IMPORT_DATA_DIR=/import \
     NATURAL_EARTH_DB=/import/natural_earth_vector.sqlite
 
+COPY --from=downloader /usr/src/app-ne/natural_earth_vector.sqlite ${IMPORT_DATA_DIR}/
 WORKDIR /usr/src/app
-COPY . /usr/src/app
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      wget \
-      unzip \
-      sqlite3 \
-    && wget --quiet http://naciscdn.org/naturalearth/packages/natural_earth_vector.sqlite.zip \
-    && unzip -oj natural_earth_vector.sqlite.zip -d /import \
-    && rm natural_earth_vector.sqlite.zip \
-    && /usr/src/app/clean-natural-earth.sh \
-    && apt-get purge -y --auto-remove \
-      wget \
-      unzip \
-      sqlite3 \
-    && rm -rf /var/lib/apt/lists/*
+COPY ./import-natural-earth.sh .
 
 CMD ["./import-natural-earth.sh"]

--- a/imports/natural-earth/README.md
+++ b/imports/natural-earth/README.md
@@ -10,14 +10,20 @@ into the container to make distribution and execution easier.
 Provide the database credentials and run `import-natural-earth`.
 
 ```bash
-docker run --rm \
-    -e POSTGRES_USER="osm" \
-    -e POSTGRES_PASSWORD="osm" \
-    -e POSTGRES_HOST="127.0.0.1" \
-    -e POSTGRES_DB="osm" \
-    -e POSTGRES_PORT="5432" \
+docker run --rm -it --net=host \
+    -e PGHOST="127.0.0.1" \
+    -e PGDATABASE="openmaptiles" \
+    -e PGUSER="openmaptiles" \
+    -e PGPASSWORD="openmaptiles" \
     openmaptiles/import-natural-earth
 ```
+
+Optional environment variables:
+* `PGPORT` (defaults to `5432`)
+* `PGCONN` - Postgres connection string to override all previous env vars
+
+Legacy env variables are still supported, but they are not recommended:
+`POSTGRES_HOST`,`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_PORT`
 
 ## Natural Earth
 Using version [4.1](https://github.com/nvkelso/natural-earth-vector/releases/tag/v4.1.0).

--- a/imports/natural-earth/import-natural-earth.sh
+++ b/imports/natural-earth/import-natural-earth.sh
@@ -1,25 +1,29 @@
-#!/bin/bash
+#!/bin/sh
 set -o errexit
-set -o pipefail
 set -o nounset
 
-readonly PGCONN="dbname=$POSTGRES_DB user=$POSTGRES_USER host=$POSTGRES_HOST password=$POSTGRES_PASSWORD port=$POSTGRES_PORT"
+# For backward compatibility, allow both PG* and POSTGRES_* forms,
+# with the non-standard POSTGRES_* form taking precedence.
+# An error will be raised if neither form is given, except for the PGPORT
+readonly PGHOST="${POSTGRES_HOST:-${PGHOST?}}"
+readonly PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
+readonly PGUSER="${POSTGRES_USER:-${PGUSER?}}"
+readonly PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
+readonly PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
 
-function import_natural_earth() {
-    echo "Importing Natural Earth to PostGIS"
-    PGCLIENTENCODING=LATIN1 ogr2ogr \
-    -progress \
-    -f Postgresql \
-    -s_srs EPSG:4326 \
-    -t_srs EPSG:3857 \
-    -clipsrc -180.1 -85.0511 180.1 85.0511 \
-    PG:"$PGCONN" \
-    -lco GEOMETRY_NAME=geometry \
-    -lco OVERWRITE=YES \
-    -lco DIM=2 \
-    -nlt GEOMETRY \
-    -overwrite \
-    "$NATURAL_EARTH_DB"
-}
+readonly PGCONN="${PGCONN:-dbname=$PGDATABASE user=$PGUSER host=$PGHOST password=$PGPASSWORD port=$PGPORT}"
 
-import_natural_earth
+echo "Importing Natural Earth to PostGIS"
+PGCLIENTENCODING=LATIN1 ogr2ogr \
+  -progress \
+  -f Postgresql \
+  -s_srs EPSG:4326 \
+  -t_srs EPSG:3857 \
+  -clipsrc -180.1 -85.0511 180.1 85.0511 \
+  PG:"${PGCONN?}" \
+  -lco GEOMETRY_NAME=geometry \
+  -lco OVERWRITE=YES \
+  -lco DIM=2 \
+  -nlt GEOMETRY \
+  -overwrite \
+  "${NATURAL_EARTH_DB?}"


### PR DESCRIPTION
Must be merged after https://github.com/openmaptiles/openmaptiles-tools/pull/88

* docker image is now based on osgeo/gdal:alpine-normal-3.0.2
* natural_earth_vector.sqlite is downloaded and cleaned-up
  in a separate, openmaptiles-tools:0.12.0 -based image
* script is now using standard PG* env vars for PostgreSQL access
* can override PGCONN