### PR TITLE
QGIS support - HEAD HTTP method for Postserve

### DIFF
--- a/openmaptiles/postserve.py
+++ b/openmaptiles/postserve.py
@@ -23,6 +23,12 @@ class RequestHandledWithCors(tornado.web.RequestHandler):
         self.set_status(204)
         self.finish()
 
+    def head(self):
+        # TODO: Technically here we should do a full tile/metadata retrieval,
+        # but without sending the actual content back.
+        # We must implement it to support QGIS
+        self.finish()
+
 
 class GetTile(RequestHandledWithCors):
     pool: Pool


### PR DESCRIPTION
QGIS requires tile servers to implement the head method.
Provide a regular 200-style response with CORS,
but without the actual tile/metadata details (TODO).