### PR TITLE
Validate geometries in test-perf and postserve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ build-tests: \
     build/mvttile_query_gzip9.sql \
     build/mvttile_query_no_feat_ids.sql \
     build/mvttile_query_no_tile_env.sql \
+    build/mvttile_query_test_geom.sql \
+    build/mvttile_query_test_geom_key.sql \
     build/doc/doc.md \
     build/sqlquery.sql \
     build/devdoc
@@ -88,6 +90,10 @@ build/mvttile_query_no_feat_ids.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --no-feature-ids             > build/mvttile_query_no_feat_ids.sql
 build/mvttile_query_no_tile_env.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --no-tile-envelope           > build/mvttile_query_no_tile_env.sql
+build/mvttile_query_test_geom.sql: prepare
+	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --test-geometry              > build/mvttile_query_test_geom.sql
+build/mvttile_query_test_geom_key.sql: prepare
+	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --test-geometry --key        > build/mvttile_query_test_geom_key.sql
 build/doc/doc.md: prepare
 	$(RUN_CMD) generate-doc      testdata/testlayers/housenumber/housenumber.yaml                           > build/doc.md
 build/sqlquery.sql: prepare

--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -8,6 +8,7 @@ Usage:
                     [--function | --prepared | --query | --psql | --raw]
                     [--layer=<layer>]... [--exclude-layers] [--key]
                     [--gzip [<gzlevel>]] [--no-feature-ids] [--no-tile-envelope]
+                    [--test-geometry]
   generate-sqltomvt --help
   generate-sqltomvt --version
 
@@ -29,6 +30,7 @@ Options:
                         You must use this flag when generating SQL for PostGIS before v3
   --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
                         You must use this flag when generating SQL for PostGIS before v3
+  -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
   --help                Show this screen.
   --version             Show version.
 """
@@ -46,6 +48,7 @@ if __name__ == '__main__':
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         use_feature_id=not args['--no-feature-ids'],
         use_tile_envelope=not args['--no-tile-envelope'],
+        test_geometry=args['--test-geometry'],
     )
 
     if args['--prepared']:

--- a/bin/postserve
+++ b/bin/postserve
@@ -8,7 +8,7 @@ Usage:
                       [--layer=<layer>]... [--exclude-layers]
                       [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
                       [--user=<user>] [--password=<password>]
-                      [--verbose]
+                      [--test-geometry] [--verbose]
   postserve --help
   postserve --version
 
@@ -25,6 +25,7 @@ Options:
                         Feature IDS are automatically disabled with PostGIS before v3
   --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
                         ST_TileEnvelope() is auto-disabled with PostGIS before v3.
+  -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
   -v --verbose          Print additional debugging information
   --help                Show this screen.
   --version             Show version.
@@ -95,5 +96,6 @@ if __name__ == '__main__':
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         disable_feature_ids=args['--no-feature-ids'],
         disable_tile_envelope=args['--no-tile-envelope'],
+        test_geometry=args['--test-geometry'],
         verbose=args.get('--verbose'),
     ).serve()

--- a/bin/test-perf
+++ b/bin/test-perf
@@ -8,7 +8,7 @@ Usage:
               ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
               [--record=<file>] [--compare=<file>] [--buckets=<count>]
               [--key] [--gzip [<gzlevel>]] [--no-color]
-              [--no-feature-ids] [--no-tile-envelope] [--verbose]
+              [--no-feature-ids] [--no-tile-envelope] [--test-geometry] [--verbose]
   test-perf --help
   test-perf --version
 
@@ -34,6 +34,7 @@ Options:
                         Feature IDS are automatically disabled with PostGIS before v3.
   --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
                         ST_TileEnvelope() is auto-disabled with PostGIS before v3.
+  -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
   -v --verbose          Print additional debugging information.
   --help                Show this screen.
   --version             Show version.
@@ -93,6 +94,7 @@ def main(args):
         disable_colors=args['--no-color'],
         disable_feature_ids=args['--no-feature-ids'],
         disable_tile_envelope=args['--no-tile-envelope'],
+        test_geometry=args['--test-geometry'],
         key_column=args['--key'],
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         verbose=args.get('--verbose'),

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -49,7 +49,8 @@ class PerfTester:
                  save_to: Union[None, str, Path], compare_with: Union[None, str, Path],
                  key_column: bool, gzip: bool, disable_colors: bool = None,
                  disable_feature_ids: bool = None, disable_tile_envelope: bool = None,
-                 verbose: bool = None, exclude_layers: bool = False):
+                 verbose: bool = None, exclude_layers: bool = False,
+                 test_geometry: bool = None):
         if disable_colors is not None:
             set_color_mode(not disable_colors)
         self.tileset = Tileset.parse(tileset)
@@ -64,6 +65,7 @@ class PerfTester:
         self.gzip = gzip
         self.disable_feature_ids = disable_feature_ids
         self.disable_tile_envelope = disable_tile_envelope
+        self.test_geometry = test_geometry
         self.verbose = verbose
         self.per_layer = per_layer
         self.save_to = Path(save_to) if save_to else None
@@ -133,6 +135,7 @@ class PerfTester:
             self.tileset,
             use_feature_id=use_feature_id,
             use_tile_envelope=use_tile_envelope,
+            test_geometry=self.test_geometry,
             gzip=self.gzip,
             key_column=self.key_column)
         self.results.layer_fields = {}

--- a/testdata/expected/mvttile_query_test_geom.sql
+++ b/testdata/expected/mvttile_query_test_geom.sql
@@ -1,0 +1,6 @@
+SELECT STRING_AGG(mvtl, '') AS mvt, SUM(COALESCE(bad_geos, 0)) as bad_geos FROM (
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl, SUM((1-COALESCE(ST_IsValid(mvtgeometry)::int, 1))+COALESCE(bad_geos, 0)) as bad_geos FROM (SELECT ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 8, true) AS mvtgeometry, (1-ST_IsValid(geometry)::int) as bad_geos, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(ST_TileEnvelope($1, $2, $3), $1)) AS t
+    UNION ALL
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl, SUM((1-COALESCE(ST_IsValid(mvtgeometry)::int, 1))+COALESCE(bad_geos, 0)) as bad_geos FROM (SELECT osm_id, ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 0, true) AS mvtgeometry, (1-ST_IsValid(geometry)::int) as bad_geos, enumfield FROM layer_enumfields(ST_TileEnvelope($1, $2, $3), $1)) AS t
+) AS all_layers
+

--- a/testdata/expected/mvttile_query_test_geom_key.sql
+++ b/testdata/expected/mvttile_query_test_geom_key.sql
@@ -1,0 +1,6 @@
+SELECT mvt, md5(mvt) AS key, bad_geos FROM (SELECT STRING_AGG(mvtl, '') AS mvt, SUM(COALESCE(bad_geos, 0)) as bad_geos FROM (
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl, SUM((1-COALESCE(ST_IsValid(mvtgeometry)::int, 1))+COALESCE(bad_geos, 0)) as bad_geos FROM (SELECT ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 8, true) AS mvtgeometry, (1-ST_IsValid(geometry)::int) as bad_geos, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(ST_TileEnvelope($1, $2, $3), $1)) AS t
+    UNION ALL
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl, SUM((1-COALESCE(ST_IsValid(mvtgeometry)::int, 1))+COALESCE(bad_geos, 0)) as bad_geos FROM (SELECT osm_id, ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 0, true) AS mvtgeometry, (1-ST_IsValid(geometry)::int) as bad_geos, enumfield FROM layer_enumfields(ST_TileEnvelope($1, $2, $3), $1)) AS t
+) AS all_layers) AS mvt_data
+


### PR DESCRIPTION
During test or tile serving via postserve,
validate that both internal geometry,
as well as the resulting MVT geometry
are both valid. If not, the number of bad
geometry counts will be returned as a separate
field.

Postserve now also prints any non-error messages
from PostgreSQL