### PR TITLE
Allow imposm of import_osm.sh to be configured

### DIFF
--- a/docker/import-osm/import_osm.sh
+++ b/docker/import-osm/import_osm.sh
@@ -25,7 +25,8 @@ function import_pbf() {
         -cachedir "$IMPOSM_CACHE_DIR" \
         -read "$pbf_file" \
         -deployproduction \
-        -write $diff_flag
+        -write $diff_flag \
+        -config "$CONFIG_JSON"
 }
 
 function import_osm_with_first_pbf() {


### PR DESCRIPTION
Configuring imposm also on import allows to produce a right last.state.txt directly at import.

Report of https://github.com/openmaptiles/import-osm/pull/15