### PR TITLE
test-perf fixes (color, postgres cli params, handle Postgis < 2.5)

### DIFF
--- a/bin/test-perf
+++ b/bin/test-perf
@@ -7,8 +7,11 @@ Usage:
               [--per-layer] [--summary] [--test-all]
               ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
               [--record=<file>] [--compare=<file>] [--buckets=<count>]
-              [--key] [--gzip [<gzlevel>]] [--no-color]
-              [--no-feature-ids] [--no-tile-envelope] [--test-geometry] [--verbose]
+              [--key] [--gzip [<gzlevel>]] [--no-color] [--no-feature-ids]
+              [--no-tile-envelope] [--test-geometry] [--verbose]
+              [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+              [--user=<user>] [--password=<password>]
+
   test-perf --help
   test-perf --version
 
@@ -16,6 +19,7 @@ Usage:
 
 Options:
   -t --test=<set>       Which predefined test to run.  [default: us-across]
+                        Use invalid value to see a list.  Use 'null' for PostGIS < v2.5
   -a --test-all         Run all available tests except 'null'
   -p --per-layer        Test each layer individually, also show per-layer summary graph.
   -s --summary          Run summary tests, without per-tile break-down.
@@ -56,10 +60,13 @@ from docopt import docopt
 
 import openmaptiles
 from openmaptiles.performance import PerfTester
+from openmaptiles.perfutils import COLOR
 from openmaptiles.utils import coalesce
 
 
 def main(args):
+    if args['--no-color']:
+        COLOR.enable(False)
     zooms = [int(v) for v in args['--zoom']]
     if not zooms:
         zooms = list(range(int(args['--minzoom']), int(args['--maxzoom']) + 1))
@@ -90,7 +97,6 @@ def main(args):
             os.getenv('PGPASSWORD'), 'openmaptiles'),
         save_to=args['--record'],
         compare_with=args['--compare'],
-        disable_colors=args['--no-color'],
         disable_feature_ids=args['--no-feature-ids'],
         disable_tile_envelope=args['--no-tile-envelope'],
         key_column=args['--key'],

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -10,7 +10,7 @@ from asyncpg import Connection
 from docopt import DocoptExit
 
 from openmaptiles.perfutils import change, PerfSummary, PerfBucket, \
-    PerfRoot, TestCase, print_graph, set_color_mode
+    PerfRoot, TestCase, print_graph, COLOR
 from openmaptiles.pgutils import show_settings
 from openmaptiles.sqltomvt import MvtGenerator
 from openmaptiles.tileset import Tileset
@@ -48,11 +48,9 @@ class PerfTester:
                  zooms: List[int], dbname: str, pghost, pgport: str, user: str,
                  password: str, summary: bool, per_layer: bool, buckets: int,
                  save_to: Union[None, str, Path], compare_with: Union[None, str, Path],
-                 key_column: bool, gzip: bool, disable_colors: bool = None,
-                 disable_feature_ids: bool = None, disable_tile_envelope: bool = None,
-                 verbose: bool = None, exclude_layers: bool = False):
-        if disable_colors is not None:
-            set_color_mode(not disable_colors)
+                 key_column: bool, gzip: bool, disable_feature_ids: bool = None,
+                 disable_tile_envelope: bool = None, exclude_layers: bool = False,
+                 verbose: bool = None):
         self.tileset = Tileset.parse(tileset)
         self.dbname = dbname
         self.pghost = pghost
@@ -113,10 +111,10 @@ class PerfTester:
                 self.save_results()
 
     async def _run(self, conn: Connection):
-        self.results.pg_settings, postgis_v3 = await show_settings(conn)
+        self.results.pg_settings, postgis_ver = await show_settings(conn)
         print("\nValidating SQL fields in all layers of the tileset")
-        use_feature_id = postgis_v3 and not self.disable_feature_ids
-        use_tile_envelope = postgis_v3 and not self.disable_tile_envelope
+        use_feature_id = postgis_ver >= 3 and not self.disable_feature_ids
+        use_tile_envelope = postgis_ver >= 3 and not self.disable_tile_envelope
         self.results.settings['use_feature_ids'] = use_feature_id
         self.results.settings['use_tile_envelope'] = use_tile_envelope
         self.mvt = MvtGenerator(
@@ -130,6 +128,11 @@ class PerfTester:
             fields = await self.mvt.validate_layer_fields(conn, layer_id, layer_def)
             self.results.layer_fields[layer_id] = list(fields.keys())
         self.test_cases = []
+        if postgis_ver < 2.5:
+            if self.tests != ['null']:
+                raise ValueError('Requires PostGIS version 2.5 or later')
+            print(f'WARN: No PostGIS v2.5 or later was found, tests will not be run.')
+            return
         old_tests = self.old_run.tests if self.old_run else None
         for layer in (self.layers if self.per_layer else [None]):
             for test in self.tests:

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -131,7 +131,7 @@ class PerfTester:
         if postgis_ver < 2.5:
             if self.tests != ['null']:
                 raise ValueError('Requires PostGIS version 2.5 or later')
-            print(f'WARN: No PostGIS v2.5 or later was found, tests will not be run.')
+            print(f'WARN: No PostGIS v2.5+ found, performance tests will not be run.')
             return
         old_tests = self.old_run.tests if self.old_run else None
         for layer in (self.layers if self.per_layer else [None]):

--- a/openmaptiles/perfutils.py
+++ b/openmaptiles/perfutils.py
@@ -12,20 +12,25 @@ from dataclasses_json import dataclass_json, config
 
 from openmaptiles.utils import round_td
 
-GREEN, RED, RESET = '', '', ''
+
+class Colors:
+    GREEN = ''
+    RED = ''
+    RESET = ''
+
+    def __init__(self) -> None:
+        self.enable(stdout.isatty())
+
+    def enable(self, enable=True):
+        if enable:
+            self.GREEN = "\x1b[32;107m"
+            self.RED = "\x1b[31;107m"
+            self.RESET = "\x1b[0m"
+        else:
+            self.GREEN, self.RED, self.RESET = '', '', ''
 
 
-def set_color_mode(enable=True):
-    global GREEN, RED, RESET
-    if enable:
-        GREEN = "\x1b[32;107m"
-        RED = "\x1b[31;107m"
-        RESET = "\x1b[0m"
-    else:
-        GREEN, RED, RESET = '', '', ''
-
-
-set_color_mode(stdout.isatty)
+COLOR = Colors()
 
 
 def change(old, new, is_speed=False, color=False):
@@ -40,8 +45,8 @@ def change(old, new, is_speed=False, color=False):
         clr = None
         value = f" {growth:+.1%}"
     else:
-        clr = GREEN if (growth > 0) == is_speed else RED
-        value = f" {clr}{growth:+.1%}{RESET}"
+        clr = COLOR.GREEN if (growth > 0) == is_speed else COLOR.RED
+        value = f" {clr}{growth:+.1%}{COLOR.RESET}"
     if color:
         return value, clr
     else:


### PR DESCRIPTION
* null test now can be used for layer field validation even for older PostGIS
* fix color handling
* support for PostgreSQL parameters (were incorrectly documented)