### PR TITLE
Refactor import-osm

### DIFF
--- a/docker/import-osm/Dockerfile
+++ b/docker/import-osm/Dockerfile
@@ -1,42 +1,17 @@
 FROM golang:1.13-buster
-MAINTAINER "Yuri Astrakhan <YuriAstrakhan@gmail.com>"
+LABEL maintainer="YuriAstrakhan@gmail.com"
 
-ENV PG_MAJOR 11
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
- # install newer packages from backports
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      libgeos-dev \
-      libleveldb-dev \
-      libprotobuf-dev \
-      osmctools \
-      osmosis \
- # install postgresql client
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      postgresql-client-$PG_MAJOR \
- && ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so \
- && rm -rf /var/lib/apt/lists/*
+ARG PG_MAJOR="11"
 
- # add  github.com/julien-noblet/download-geofabrik
-RUN go get github.com/julien-noblet/download-geofabrik \
- && go install  github.com/julien-noblet/download-geofabrik \
- && download-geofabrik generate \
- # add  github.com/osm2vectortiles/imposm3
- && mkdir -p $GOPATH/src/github.com/omniscale/imposm3 \
- && cd  $GOPATH/src/github.com/omniscale/imposm3 \
- && go get github.com/tools/godep \
- # && git clone --quiet --depth 1 https://github.com/omniscale/imposm3 \
- #
- # update to current omniscale/imposm3
- && git clone --quiet --depth 1 https://github.com/openmaptiles/imposm3.git -b v2017-10-18 \
-        $GOPATH/src/github.com/omniscale/imposm3 \
- && make build \
- && mv imposm3 /usr/bin/imposm3 \
- # clean
- && rm -rf $GOPATH/bin/godep \
- && rm -rf $GOPATH/src/ \
- && rm -rf $GOPATH/pkg/
+# By default for now use custom build until we verify everything is stable
+ARG IMPOSM_REPO="https://github.com/openmaptiles/imposm3.git"
+ARG IMPOSM_VERSION="v2017-10-18"
 
-VOLUME /import /cache /mapping
+# Current version, disable for now
+#ARG IMPOSM_REPO="https://github.com/omniscale/imposm3.git"
+#ARG IMPOSM_VERSION="v0.8.1"
+
+
 ENV IMPORT_DIR=/import \
     IMPOSM_CACHE_DIR=/cache \
     MAPPING_YAML=/mapping/mapping.yaml \
@@ -44,6 +19,47 @@ ENV IMPORT_DIR=/import \
     TILES_DIR=/import \
     CONFIG_JSON=config.json
 
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+ #
+ # install newer packages from backports
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      libgeos-dev \
+      libleveldb-dev \
+      libprotobuf-dev \
+      osmctools \
+      osmosis \
+      # install postgresql client
+      postgresql-client-$PG_MAJOR \
+ #
+ && ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so \
+ && rm -rf /var/lib/apt/lists/* \
+ #
+ # add  github.com/julien-noblet/download-geofabrik
+ && go get github.com/julien-noblet/download-geofabrik \
+ && go install github.com/julien-noblet/download-geofabrik \
+ && download-geofabrik generate \
+ #
+ # add  github.com/osm2vectortiles/imposm3
+ && mkdir -p $GOPATH/src/github.com/omniscale/imposm3 \
+ && cd  $GOPATH/src/github.com/omniscale/imposm3 \
+ && go get github.com/tools/godep \
+ #
+ # get and build specific version of imposm
+ && git clone --quiet --depth 1 $IMPOSM_REPO -b $IMPOSM_VERSION \
+        $GOPATH/src/github.com/omniscale/imposm3 \
+ && make build \
+ #
+ # Support legacy imposm3 as well as the newer imposm app name
+ && ( [ -f imposm ] && mv imposm /usr/bin/imposm || mv imposm3 /usr/bin/imposm ) \
+ && ln -s /usr/bin/imposm /usr/bin/imposm3 \
+ #
+ # clean
+ && rm -rf $GOPATH/bin/godep \
+ && rm -rf $GOPATH/src/ \
+ && rm -rf $GOPATH/pkg/
+
+VOLUME /import /cache /mapping
 WORKDIR /usr/src/app
 COPY . /usr/src/app/
 CMD ["./import_osm.sh"]

--- a/docker/import-osm/Makefile
+++ b/docker/import-osm/Makefile
@@ -2,14 +2,31 @@ VERSION := $(shell cat ../../VERSION)
 DOCKER_IMAGE := openmaptiles/import-osm
 
 .PHONY: build
-
 build:
 	@echo "Build: $(VERSION)"
-	docker build -f Dockerfile      -t $(DOCKER_IMAGE):$(VERSION)      .
+	docker build -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION) .
 	docker images | grep $(DOCKER_IMAGE) | grep $(VERSION)
 
+.PHONY: release
 release:
 	@echo "Release: $(VERSION)"
-	docker pull golang:1.8
-	docker build -f Dockerfile      -t $(DOCKER_IMAGE):$(VERSION)      .
+	docker build --pull -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION) .
 	docker images | grep $(DOCKER_IMAGE) | grep $(VERSION)
+
+# Build with custom legacy imposm version
+.PHONY: release-legacy
+release-legacy:
+	docker build \
+		--build-arg IMPOSM_REPO="https://github.com/openmaptiles/imposm3.git" \
+		--build-arg IMPOSM_VERSION="v2017-10-18" \
+		--pull -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION)-legacy .
+	docker images | grep $(DOCKER_IMAGE) | grep $(VERSION)-legacy
+
+# Build latest stable imposm version
+.PHONY: release-latest
+release-latest:
+	docker build \
+		--build-arg IMPOSM_REPO="https://github.com/omniscale/imposm3.git" \
+		--build-arg IMPOSM_VERSION="v0.8.1" \
+		--pull -f Dockerfile -t $(DOCKER_IMAGE):$(VERSION)-stable .
+	docker images | grep $(DOCKER_IMAGE) | grep $(VERSION)-stable

--- a/docker/import-osm/README.md
+++ b/docker/import-osm/README.md
@@ -24,11 +24,16 @@ Volumes:
 docker run --rm \
     -v $(pwd):/import \
     -v $(pwd):/mapping \
-    -e POSTGRES_USER="osm" \
-    -e POSTGRES_PASSWORD="osm" \
-    -e POSTGRES_HOST="127.0.0.1" \
-    -e POSTGRES_DB="osm" \
-    -e POSTGRES_PORT="5432" \
+    -e PGHOST="127.0.0.1" \
+    -e PGDATABASE="openmaptiles" \
+    -e PGUSER="openmaptiles" \
+    -e PGPASSWORD="openmaptiles" \
     openmaptiles/import-osm
 ```
+
+Use standard Postgres [environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) to connect,
+such as `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGPORT`.  All are required except for `PGPORT`.
+
+For backward compatibility the script also supports `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`,
+`POSTGRES_PASSWORD`, and `POSTGRES_PORT`, but they are not recommended.
 

--- a/docker/import-osm/download-geofabrik-list.sh
+++ b/docker/import-osm/download-geofabrik-list.sh
@@ -6,4 +6,3 @@ set -o nounset
 
 download-geofabrik generate
 download-geofabrik list
-

--- a/docker/import-osm/download-geofabrik.sh
+++ b/docker/import-osm/download-geofabrik.sh
@@ -13,31 +13,31 @@ fi
 AREA=$1
 DOCKER_COMPOSE_FILE=./docker-compose-config.yml
 
-rm -f *.osm.pbf
-rm -f *.mbtiles
-rm -f *.txt
-rm -f *.yml
+rm -f ./*.osm.pbf
+rm -f ./*.mbtiles
+rm -f ./*.txt
+rm -f ./*.yml
 
-download-geofabrik generate
-download-geofabrik -v download $AREA
-download-geofabrik -s download $AREA
+download-geofabrik --verbose generate
+download-geofabrik --verbose download --state "$AREA"
+download-geofabrik --verbose download "$AREA"
 
-mv ${AREA}.state last.state.txt
+mv "${AREA}.state" last.state.txt
 
-ls *.osm.pbf  -la
-osmconvert  --out-statistics  ${AREA}.osm.pbf  > ./osmstat.txt
+ls -la ./*.osm.pbf
+osmconvert  --out-statistics  "${AREA}.osm.pbf"  > ./osmstat.txt
 
-lon_min=$( cat osmstat.txt | grep "lon min:" |cut -d":" -f 2 )
-lon_max=$( cat osmstat.txt | grep "lon max:" |cut -d":" -f 2 )
-lat_min=$( cat osmstat.txt | grep "lat min:" |cut -d":" -f 2 )
-lat_max=$( cat osmstat.txt | grep "lat max:" |cut -d":" -f 2 )
-timestamp_max=$( cat osmstat.txt | grep "timestamp max:" |cut -d" " -f 3 )
+lon_min=$( cat osmstat.txt | grep "lon min:" | cut -d":" -f 2 )
+lon_max=$( cat osmstat.txt | grep "lon max:" | cut -d":" -f 2 )
+lat_min=$( cat osmstat.txt | grep "lat min:" | cut -d":" -f 2 )
+lat_max=$( cat osmstat.txt | grep "lat max:" | cut -d":" -f 2 )
+timestamp_max=$( cat osmstat.txt | grep "timestamp max:" | cut -d" " -f 3 )
 
 echo "--------------------------------------------"
-echo BBOX: "$lon_min,$lat_min,$lon_max,$lat_max"
-echo TIMESTAMP MAX = $timestamp_max
-echo QUICKSTART_MIN_ZOOM: "$QUICKSTART_MIN_ZOOM"
-echo QUICKSTART_MAX_ZOOM: "$QUICKSTART_MAX_ZOOM"
+echo "BBOX: $lon_min,$lat_min,$lon_max,$lat_max"
+echo "TIMESTAMP MAX = $timestamp_max"
+echo "QUICKSTART_MIN_ZOOM: $QUICKSTART_MIN_ZOOM"
+echo "QUICKSTART_MAX_ZOOM: $QUICKSTART_MAX_ZOOM"
 echo "--------------------------------------------"
 
 cat > $DOCKER_COMPOSE_FILE  <<- EOM
@@ -51,5 +51,3 @@ services:
       MIN_ZOOM: "$QUICKSTART_MIN_ZOOM"
       MAX_ZOOM: "$QUICKSTART_MAX_ZOOM"
 EOM
-
-

--- a/docker/import-osm/import_diff.sh
+++ b/docker/import-osm/import_diff.sh
@@ -3,17 +3,26 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly PG_CONNECT="postgis://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+# For backward compatibility, allow both PG* and POSTGRES_* forms,
+# with the non-standard POSTGRES_* form taking precedence.
+# An error will be raised if neither form is given, except for the PGPORT
+export PGHOST="${POSTGRES_HOST:-${PGHOST?}}"
+export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
+export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
+export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
+
 
 function import_diff() {
-    imposm3 diff \
-        -connection "$PG_CONNECT" \
+    imposm diff \
+        -connection "postgis://$PGUSER:$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE" \
         -mapping "$MAPPING_YAML" \
         -cachedir "$IMPOSM_CACHE_DIR" \
         -diffdir "$IMPORT_DIR" \
         -expiretiles-dir "$IMPORT_DIR" \
         -expiretiles-zoom 14 \
-        -config $CONFIG_JSON "$IMPORT_DIR/changes.osc.gz"
+        -config "$CONFIG_JSON" \
+        "$IMPORT_DIR/changes.osc.gz"
 }
 
 import_diff

--- a/docker/import-osm/import_osm.sh
+++ b/docker/import-osm/import_osm.sh
@@ -3,8 +3,17 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly PG_CONNECT="postgis://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
-readonly DIFF_MODE=${DIFF_MODE:-true}
+# For backward compatibility, allow both PG* and POSTGRES_* forms,
+# with the non-standard POSTGRES_* form taking precedence.
+# An error will be raised if neither form is given, except for the PGPORT
+export PGHOST="${POSTGRES_HOST:-${PGHOST?}}"
+export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
+export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
+export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
+
+
+: "${DIFF_MODE:=true}"
 
 
 function import_pbf() {
@@ -17,8 +26,8 @@ function import_pbf() {
         echo "Importing in normal mode"
     fi
 
-    imposm3 import \
-        -connection "$PG_CONNECT" \
+    imposm import \
+        -connection "postgis://$PGUSER:$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE" \
         -mapping "$MAPPING_YAML" \
         -overwritecache \
         -diffdir "$DIFF_DIR" \
@@ -33,13 +42,13 @@ function import_osm_with_first_pbf() {
     if [ "$(ls -A $IMPORT_DIR/*.pbf 2> /dev/null)" ]; then
         local pbf_file
         for pbf_file in "$IMPORT_DIR"/*.pbf; do
-			import_pbf "$pbf_file"
+            import_pbf "$pbf_file"
             break
         done
     else
         echo "No PBF files for import found."
         echo "Please mount the $IMPORT_DIR volume to a folder containing OSM PBF files."
-        exit 404
+        exit 1
     fi
 }
 

--- a/docker/import-osm/import_update.sh
+++ b/docker/import-osm/import_update.sh
@@ -3,17 +3,24 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-readonly PG_CONNECT="postgis://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
+# For backward compatibility, allow both PG* and POSTGRES_* forms,
+# with the non-standard POSTGRES_* form taking precedence.
+# An error will be raised if neither form is given, except for the PGPORT
+export PGHOST="${POSTGRES_HOST:-${PGHOST?}}"
+export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
+export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
+export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
 
 function update() {
-    imposm3 run \
-        -connection "$PG_CONNECT" \
+    imposm run \
+        -connection "postgis://$PGUSER:$PGPASSWORD@$PGHOST:$PGPORT/$PGDATABASE" \
         -mapping "$MAPPING_YAML" \
         -cachedir "$IMPOSM_CACHE_DIR" \
         -diffdir "$DIFF_DIR" \
         -expiretiles-dir "$TILES_DIR" \
         -expiretiles-zoom 14 \
-        -config $CONFIG_JSON
+        -config "$CONFIG_JSON"
 }
 
 update


### PR DESCRIPTION
* BREAKING: if there are no /import/*.pbf files, exit error is now 1 instead of 404 (numbers above 255 are not valid in exit codes)
* parametrize which imposm version is built. Keep custom legacy one as default for now.
* use standard PG* env vars in addition to the legacy POSTGRES_* env vars.
* allow `imposm` in addition to `imposm3` to run the same program (imposm3 is obsolete in stable)
* make file now allows two additional targets to simplify legacy and current rebuilt
* added pgwait.sh script to wait until postgreSQL has started

cc: @frodrigo