### PR TITLE
Parallelize import-water and import-osmborder

### DIFF
--- a/docker/import-osmborder/README.md
+++ b/docker/import-osmborder/README.md
@@ -11,6 +11,7 @@ The **import-osmborder** will import the embedded CSV into the database.
 
 ```bash
 docker run --rm \
+    -e PARALLEL=1 \
     -e PGHOST="127.0.0.1" \
     -e PGDATABASE="openmaptiles" \
     -e PGUSER="openmaptiles" \

--- a/docker/import-osmborder/import_osmborder_lines.sh
+++ b/docker/import-osmborder/import_osmborder_lines.sh
@@ -62,45 +62,31 @@ function import_borders() {
     create_import_table "$table_name"
     import_csv "$csv_file" "$table_name"
 
-    local gen1_table_name="osm_border_linestring_gen1"
-    drop_table "$gen1_table_name"
-    generalize_border "$gen1_table_name" "$table_name" 10 10
+    local gen_tables="
+        osm_border_linestring_gen1,10,10
+        osm_border_linestring_gen2,20,10
+        osm_border_linestring_gen3,40,8
+        osm_border_linestring_gen4,80,6
+        osm_border_linestring_gen5,160,6
+        osm_border_linestring_gen6,300,4
+        osm_border_linestring_gen7,600,4
+        osm_border_linestring_gen8,1200,4
+        osm_border_linestring_gen9,2400,4
+        osm_border_linestring_gen10,4800,2
+    "
 
-    local gen2_table_name="osm_border_linestring_gen2"
-    drop_table "$gen2_table_name"
-    generalize_border "$gen2_table_name" "$table_name" 20 10
+    for params in $gen_tables; do
+        IFS=',' read gen_table_name tolerance max_admin_level <<< "${params}"
+        drop_table "$gen_table_name"
+        generalize_border "$gen_table_name" "$table_name" $tolerance $max_admin_level &
 
-    local gen3_table_name="osm_border_linestring_gen3"
-    drop_table "$gen3_table_name"
-    generalize_border "$gen3_table_name" "$table_name" 40 8
+        if [ ! ${PARALLEL:-0} = 1 ]; then
+            wait
+        fi
+    done
 
-    local gen4_table_name="osm_border_linestring_gen4"
-    drop_table "$gen4_table_name"
-    generalize_border "$gen4_table_name" "$table_name" 80 6
-
-    local gen5_table_name="osm_border_linestring_gen5"
-    drop_table "$gen5_table_name"
-    generalize_border "$gen5_table_name" "$table_name" 160 6
-
-    local gen6_table_name="osm_border_linestring_gen6"
-    drop_table "$gen6_table_name"
-    generalize_border "$gen6_table_name" "$table_name" 300 4
-
-    local gen7_table_name="osm_border_linestring_gen7"
-    drop_table "$gen7_table_name"
-    generalize_border "$gen7_table_name" "$table_name" 600 4
-
-    local gen8_table_name="osm_border_linestring_gen8"
-    drop_table "$gen8_table_name"
-    generalize_border "$gen8_table_name" "$table_name" 1200 4
-
-    local gen9_table_name="osm_border_linestring_gen9"
-    drop_table "$gen9_table_name"
-    generalize_border "$gen9_table_name" "$table_name" 2400 4
-
-    local gen10_table_name="osm_border_linestring_gen10"
-    drop_table "$gen10_table_name"
-    generalize_border "$gen10_table_name" "$table_name" 4800 2
+    wait
+    echo "Finished border generalization"
 }
 
 import_borders "$IMPORT_DIR/osmborder_lines.csv"

--- a/docker/import-water/README.md
+++ b/docker/import-water/README.md
@@ -10,6 +10,7 @@ Provide the database credentials and run `import-water`.
 
 ```bash
 docker run --rm \
+    -e PARALLEL=1 \
     -e PGHOST="127.0.0.1" \
     -e PGDATABASE="openmaptiles" \
     -e PGUSER="openmaptiles" \

--- a/docker/import-water/import-water.sh
+++ b/docker/import-water/import-water.sh
@@ -45,21 +45,25 @@ function import_water() {
     drop_table "$table_name"
     import_shp "$WATER_POLYGONS_FILE" "$table_name"
 
-    local gen1_table_name="osm_ocean_polygon_gen1"
-    drop_table "$gen1_table_name"
-    generalize_water "$gen1_table_name" "$table_name" 20
+    local gen_tables="
+        osm_ocean_polygon_gen1,20
+        osm_ocean_polygon_gen2,40
+        osm_ocean_polygon_gen3,80
+        osm_ocean_polygon_gen4,160
+    "
 
-    local gen2_table_name="osm_ocean_polygon_gen2"
-    drop_table "$gen2_table_name"
-    generalize_water "$gen2_table_name" "$table_name" 40
+    for params in $gen_tables; do
+        IFS=',' read gen_table_name tolerance <<< "${params}"
+        drop_table "$gen_table_name"
+        generalize_water "$gen_table_name" "$table_name" $tolerance &
 
-    local gen3_table_name="osm_ocean_polygon_gen3"
-    drop_table "$gen3_table_name"
-    generalize_water "$gen3_table_name" "$table_name" 80
+        if [ ! ${PARALLEL:-0} = 1 ]; then
+            wait
+        fi
+    done
 
-    local gen4_table_name="osm_ocean_polygon_gen4"
-    drop_table "$gen4_table_name"
-    generalize_water "$gen4_table_name" "$table_name" 160
+    wait
+    echo "Finished water generalization"
 }
 
 import_water


### PR DESCRIPTION
Parallelize the simplifications of water and osmborders. This can mainly help a lot for the dev workflow as these imports may be slow compared to other operations over a small region.

As this can lead to logs harder to interpret, this behavior is disabled by default.

This conflicts with the refactor of `import-water` (https://github.com/openmaptiles/openmaptiles-tools/pull/115). As I wasn't sure how to adapt I thought it would be better to just suggest this small change and get any advice on how to integrate it if needed.