### PR TITLE
Adding admin_level 5 and 6 into _gen6 and _gen7 tables

### DIFF
--- a/docker/import-osmborder/import_osmborder_lines.sh
+++ b/docker/import-osmborder/import_osmborder_lines.sh
@@ -84,11 +84,11 @@ function import_borders() {
 
     local gen6_table_name="osm_border_linestring_gen6"
     drop_table "$gen6_table_name"
-    generalize_border "$gen6_table_name" "$table_name" 300 4
+    generalize_border "$gen6_table_name" "$table_name" 300 6
 
     local gen7_table_name="osm_border_linestring_gen7"
     drop_table "$gen7_table_name"
-    generalize_border "$gen7_table_name" "$table_name" 600 4
+    generalize_border "$gen7_table_name" "$table_name" 600 6
 
     local gen8_table_name="osm_border_linestring_gen8"
     drop_table "$gen8_table_name"


### PR DESCRIPTION
Connected to https://github.com/openmaptiles/openmaptiles/pull/617.
I propose we accept this change even in the case https://github.com/openmaptiles/openmaptiles/pull/617 will not be merged - for more variability.

In future we should move this generalization step into https://github.com/openmaptiles/openmaptiles/blob/master/layers/boundary/boundary.sql.