### PR TITLE
Add tool to examine MVT tiles directly from SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ You can view tiles with any MVT-supporting viewer, such as:
 * [Maputnik editor](https://maputnik.github.io/editor) (online) -- change the data source to `http://localhost:8090`
 * [QGIS desktop](https://www.qgis.org/en/site/) -- add `Vector Tiles Reader` plugin, and add a vector tile server connection with TileJSON URL set to `http://localhost:8090`.
 
+### Examining realtime tile content
+
+Use `debug-mvt` tool to examine tile content. The tool will query PostgreSQL server and show layers with each data row and geometry type/size.
+This tool can limit output to just a few layers, optionally show all localized names, and show geometries as text.
+
+```bash
+# Query tile 3/4/2 and show values in the "place" layer
+debug-mvt openmaptiles.yaml 3/4/2 -l place
+```
 
 ## Scripts
 

--- a/bin/debug-mvt
+++ b/bin/debug-mvt
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+"""
+This is a simple vector tile server that returns a PBF tile for  /tiles/{z}/{x}/{y}.pbf  requests
+
+Usage:
+  debug-mvt <tileset> <tile_zxy> [--layer=<layer>]... [--exclude-layers]
+                      [--show-names] [--show-geometry]
+                      [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+                      [--user=<user>] [--password=<password>]
+  debug-mvt --help
+  debug-mvt --version
+
+  <tileset>             Tileset definition yaml file
+  <tile_zxy>            Tile ID, e.g. "10/4/8" for zoom=10, x=4, y=8
+
+Options:
+  -l --layer=<layer>    If set, limit tile generation to just this layer (could be multiple)
+  -x --exclude-layers   If set, uses all layers except the ones listed with -l (-l is required)
+  -n --show-names       if set, includes all localized names
+  -g --show-geometry    If set, shows geometry as text instead of type+length
+  --help                Show this screen.
+  --version             Show version.
+
+POSTGRES options:
+  -h --pghost=<host>    Postgres hostname. By default uses POSTGRES_HOST env or "localhost" if not set.
+  -P --pgport=<port>    Postgres port. By default uses POSTGRES_PORT env or "5432" if not set.
+  -d --dbname=<db>      Postgres db name. By default uses POSTGRES_DB env or "openmaptiles" if not set.
+  -U --user=<user>      Postgres user. By default uses POSTGRES_USER env or "openmaptiles" if not set.
+  --password=<password> Postgres password. By default uses POSTGRES_PASSWORD env or "openmaptiles" if not set.
+"""
+import asyncio
+import re
+
+import asyncpg
+from docopt import docopt, DocoptExit
+from tabulate import tabulate
+
+import openmaptiles
+from openmaptiles.language import languages_to_sql
+from openmaptiles.pgutils import show_settings, parse_pg_args
+from openmaptiles.sqltomvt import MvtGenerator
+from openmaptiles.tileset import Tileset
+
+
+async def main(args):
+    pghost, pgport, dbname, user, password = parse_pg_args(args)
+    exclude_layers = args['--exclude-layers']
+    layers = args['--layer']
+    show_names = args['--show-names']
+    show_geometry = args['--show-geometry']
+    tileset_path = args['<tileset>']
+    zxy = args['<tile_zxy>']
+    if not re.match(r'\d+/\d+/\d+', zxy):
+        raise DocoptExit('Invalid <tile_zxy> - must be in the form "zoom/x/y"')
+    zoom, x, y = [int(v) for v in zxy.split('/')]
+
+    tileset = Tileset.parse(tileset_path)
+    conn = await asyncpg.connect(
+        database=dbname, host=pghost, port=pgport, user=user, password=password,
+    )
+    pg_settings, postgis_ver = await show_settings(conn, get_ver=True)
+    if postgis_ver < 2.5:
+        raise ValueError('Requires PostGIS version 2.5 or later')
+    mvt = MvtGenerator(
+        tileset,
+        layer_ids=layers,
+        use_feature_id=postgis_ver >= 3,
+        use_tile_envelope=postgis_ver >= 3,
+        exclude_layers=exclude_layers)
+
+    if show_names:
+        name_languages = languages_to_sql(tileset.definition.get('languages', []))
+    else:
+        name_languages = 'NULL as hiden_names'
+    for layer_id, layer_def in mvt.get_layers():
+        source = layer_def.definition['layer']['datasource']
+        query = source['query']
+        query = query.format(name_languages=name_languages)
+        query = mvt.substitute_sql(query,
+                                   f"{mvt.tile_envelope}({zoom},{x},{y})", str(zoom))
+        key_fld = source['key_field'] if 'key_field' in source else False
+        geom_fld = layer_def.geometry_field
+        if show_geometry:
+            geom_repl = f"ST_AsText({geom_fld}) AS {geom_fld}"
+        else:
+            geom_repl = f"GeometryType({geom_fld}) || '(' || ST_MemSize({geom_fld}) || ')' AS {geom_fld}"
+        query = query.replace(geom_fld, geom_repl)
+
+        def field_sorter(v):
+            """Move osm_id and geometry fields to the right"""
+            key = v[0]
+            return 'zzz0' if key == key_fld else 'zzz1' if key == geom_fld else key
+
+        result = []
+        for row in await conn.fetch(f"SELECT * FROM {query}"):
+            vals = {v[0]: v[1] for v in sorted(row.items(), key=field_sorter)}
+            result.append(vals)
+
+        if result:
+            print(f"======= Layer {layer_id} =======")
+            print(tabulate(result, headers="keys"))
+        else:
+            print(f"======= No data in layer {layer_id}")
+
+
+if __name__ == '__main__':
+    asyncio.run(main(docopt(__doc__, version=openmaptiles.__version__)))

--- a/bin/postserve
+++ b/bin/postserve
@@ -43,15 +43,18 @@ Additional ENV variables:
     METADATA_NAME, METADATA_ID, METADATA_VERSION,
     METADATA_ATTRIBUTION, METADATA_DESCRIPTION, METADATA_TYPE
 """
-from docopt import docopt
 import os.path
-import openmaptiles
-from openmaptiles.postserve import Postserve
-from openmaptiles.utils import Bbox, coalesce
-from openmaptiles.consts import *
 
-if __name__ == '__main__':
-    args = docopt(__doc__, version=openmaptiles.__version__)
+from docopt import docopt
+
+import openmaptiles
+from openmaptiles.consts import *
+from openmaptiles.pgutils import parse_pg_args
+from openmaptiles.postserve import Postserve
+from openmaptiles.utils import Bbox
+
+
+def main(args):
     bbox = Bbox(bbox=os.environ.get('BBOX'),
                 center_zoom=os.environ.get('CENTER_ZOOM', CENTER_ZOOM))
     metadata = dict(
@@ -68,25 +71,15 @@ if __name__ == '__main__':
         pixel_scale=PIXEL_SCALE,
         tilejson="2.0.0",
     )
-
+    pghost, pgport, dbname, user, password = parse_pg_args(args)
     Postserve(
         host=args['--serve'],
         port=int(args['--port']),
-        pghost=coalesce(
-            args.get("--pghost"), os.getenv('POSTGRES_HOST'), os.getenv('PGHOST'),
-            'localhost'),
-        pgport=coalesce(
-            args.get("--pgport"), os.getenv('POSTGRES_PORT'), os.getenv('PGPORT'),
-            '5432'),
-        dbname=coalesce(
-            args.get("--dbname"), os.getenv('POSTGRES_DB'), os.getenv('PGDATABASE'),
-            'openmaptiles'),
-        user=coalesce(
-            args.get("--user"), os.getenv('POSTGRES_USER'), os.getenv('PGUSER'),
-            'openmaptiles'),
-        password=coalesce(
-            args.get("--password"), os.getenv('POSTGRES_PASSWORD'),
-            os.getenv('PGPASSWORD'), 'openmaptiles'),
+        pghost=pghost,
+        pgport=pgport,
+        dbname=dbname,
+        user=user,
+        password=password,
         metadata=metadata,
         layers=args['--layer'],
         exclude_layers=args['--exclude-layers'],
@@ -99,3 +92,7 @@ if __name__ == '__main__':
         test_geometry=args['--test-geometry'],
         verbose=args.get('--verbose'),
     ).serve()
+
+
+if __name__ == '__main__':
+    main(docopt(__doc__, version=openmaptiles.__version__))

--- a/bin/refresh-views
+++ b/bin/refresh-views
@@ -26,7 +26,6 @@ Postgres
      POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
 """
 import asyncio
-import os.path
 from collections import defaultdict
 from datetime import datetime
 from typing import List
@@ -35,29 +34,20 @@ import asyncpg
 from docopt import docopt
 
 import openmaptiles
+from openmaptiles.pgutils import parse_pg_args
 from openmaptiles.utils import Action, run_actions
-from openmaptiles.utils import coalesce
 
 
 def main(args):
+    pghost, pgport, dbname, user, password = parse_pg_args(args)
     asyncio.run(async_main(
         max_queries=int(args['--parallel']),
         schema=args['--schema'],
-        pghost=coalesce(
-            args.get("--pghost"), os.getenv('POSTGRES_HOST'), os.getenv('PGHOST'),
-            'localhost'),
-        pgport=coalesce(
-            args.get("--pgport"), os.getenv('POSTGRES_PORT'), os.getenv('PGPORT'),
-            '5432'),
-        dbname=coalesce(
-            args.get("--dbname"), os.getenv('POSTGRES_DB'), os.getenv('PGDATABASE'),
-            'openmaptiles'),
-        user=coalesce(
-            args.get("--user"), os.getenv('POSTGRES_USER'), os.getenv('PGUSER'),
-            'openmaptiles'),
-        password=coalesce(
-            args.get("--password"), os.getenv('POSTGRES_PASSWORD'),
-            os.getenv('PGPASSWORD'), 'openmaptiles'),
+        pghost=pghost,
+        pgport=pgport,
+        dbname=dbname,
+        user=user,
+        password=password,
         verbose=args.get('--verbose'),
     ))
 

--- a/bin/test-perf
+++ b/bin/test-perf
@@ -54,14 +54,13 @@ Postgres
      POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
 """
 import asyncio
-import os.path
 
 from docopt import docopt
 
 import openmaptiles
 from openmaptiles.performance import PerfTester
 from openmaptiles.perfutils import COLOR
-from openmaptiles.utils import coalesce
+from openmaptiles.pgutils import parse_pg_args
 
 
 def main(args):
@@ -70,6 +69,7 @@ def main(args):
     zooms = [int(v) for v in args['--zoom']]
     if not zooms:
         zooms = list(range(int(args['--minzoom']), int(args['--maxzoom']) + 1))
+    pghost, pgport, dbname, user, password = parse_pg_args(args)
     perf = PerfTester(
         tileset=args['<tileset>'],
         tests=args['--test'],
@@ -80,21 +80,11 @@ def main(args):
         exclude_layers=args['--exclude-layers'],
         buckets=int(args['--buckets']),
         zooms=zooms,
-        pghost=coalesce(
-            args.get("--pghost"), os.getenv('POSTGRES_HOST'), os.getenv('PGHOST'),
-            'localhost'),
-        pgport=coalesce(
-            args.get("--pgport"), os.getenv('POSTGRES_PORT'), os.getenv('PGPORT'),
-            '5432'),
-        dbname=coalesce(
-            args.get("--dbname"), os.getenv('POSTGRES_DB'), os.getenv('PGDATABASE'),
-            'openmaptiles'),
-        user=coalesce(
-            args.get("--user"), os.getenv('POSTGRES_USER'), os.getenv('PGUSER'),
-            'openmaptiles'),
-        password=coalesce(
-            args.get("--password"), os.getenv('POSTGRES_PASSWORD'),
-            os.getenv('PGPASSWORD'), 'openmaptiles'),
+        pghost=pghost,
+        pgport=pgport,
+        dbname=dbname,
+        user=user,
+        password=password,
         save_to=args['--record'],
         compare_with=args['--compare'],
         disable_feature_ids=args['--no-feature-ids'],

--- a/openmaptiles/mbtile_tools.py
+++ b/openmaptiles/mbtile_tools.py
@@ -134,9 +134,9 @@ class Imputer:
             if self.verbose:
                 for k, c in key_stats.items():
                     print_err(f"{k} - added {c:,}")
-                print_err(f'Total changes made - {keyed_tiles}')
+                print_err(f'Total imputed tiles: {keyed_tiles:,}')
                 if nokey_tiles:
-                    print_err(f'Total tiles need to be generated - {nokey_tiles}')
+                    print_err(f'Total tiles need to be generated: {nokey_tiles:,}')
 
     def tile_batches(self, conn: sqlite3.Connection, limit_to_keys=False):
         """Generate batches of tiles to be processed for the new zoom,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml==5.1.2
 tornado==6.0.3
 ascii_graph==1.5.1
 dataclasses-json==0.3.5
+tabulate==0.8.6


### PR DESCRIPTION
Use `debug-mvt` tool to examine tile content. The tool will query PostgreSQL server and show layers with each data row and geometry type/size.
This tool can limit output to just a few layers, optionally show all localized names, and show geometries as text.

![image](https://user-images.githubusercontent.com/1641515/70368264-723c8d80-1876-11ea-97e1-0cb821e00313.png)

```
# Query tile 3/4/2 and show values in the "place" layer
debug-mvt openmaptiles.yaml 3/4/2 -l place
```

Cleanup - consolidated postgres parameter parsing