### PR TITLE
Refactor MVT bbox handling (noop)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .git/
 .gitignore
 .travis.yml
-build/
 docker-run.sh
 Dockerfile
 docs/

--- a/bin/debug-mvt
+++ b/bin/debug-mvt
@@ -63,10 +63,12 @@ async def main(args):
         raise ValueError('Requires PostGIS version 2.5 or later')
     mvt = MvtGenerator(
         tileset,
+        zoom=zoom, x=x, y=y,
         layer_ids=layers,
         use_feature_id=postgis_ver >= 3,
         use_tile_envelope=postgis_ver >= 3,
-        exclude_layers=exclude_layers)
+        exclude_layers=exclude_layers,
+    )
 
     if show_names:
         name_languages = languages_to_sql(tileset.definition.get('languages', []))
@@ -76,8 +78,7 @@ async def main(args):
         source = layer_def.definition['layer']['datasource']
         query = source['query']
         query = query.format(name_languages=name_languages)
-        query = mvt.substitute_sql(query,
-                                   f"{mvt.tile_envelope}({zoom},{x},{y})", str(zoom))
+        query = mvt.substitute_sql(query, layer_def, zoom, x, y)
         key_fld = source['key_field'] if 'key_field' in source else False
         geom_fld = layer_def.geometry_field
         if show_geometry:

--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -40,8 +40,18 @@ from openmaptiles.sqltomvt import MvtGenerator
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
+    if args['--prepared'] or args['--query']:
+        zoom, x, y = '$1', '$2', '$3'
+    elif args['--psql']:
+        zoom, x, y = ':zoom', ':x', ':y'
+    elif args['--raw']:
+        zoom, x, y = None, None, None
+    else:
+        zoom, x, y = 'zoom', 'x', 'y'
+
     mvt = MvtGenerator(
         tileset=args['<tileset>'],
+        zoom=zoom, x=x, y=y,
         layer_ids=args['--layer'],
         exclude_layers=args['--exclude-layers'],
         key_column=args['--key'],
@@ -53,12 +63,8 @@ if __name__ == '__main__':
 
     if args['--prepared']:
         sql = mvt.generate_sqltomvt_preparer(args['--fname'])
-    elif args['--query']:
-        sql = mvt.generate_sqltomvt_query()
-    elif args['--psql']:
-        sql = mvt.generate_sqltomvt_psql()
-    elif args['--raw']:
-        sql = mvt.generate_sqltomvt_raw()
+    elif args['--query'] or args['--psql'] or args['--raw']:
+        sql = mvt.generate_sql()
     else:
         # --function or default
         sql = mvt.generate_sqltomvt_func(args['--fname'])

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -119,10 +119,12 @@ class PerfTester:
         self.results.settings['use_tile_envelope'] = use_tile_envelope
         self.mvt = MvtGenerator(
             self.tileset,
+            zoom='$1', x='xval.x', y='yval.y',
             use_feature_id=use_feature_id,
             use_tile_envelope=use_tile_envelope,
             gzip=self.gzip,
-            key_column=self.key_column)
+            key_column=self.key_column,
+        )
         self.results.layer_fields = {}
         for layer_id, layer_def in self.mvt.get_layers():
             fields = await self.mvt.validate_layer_fields(conn, layer_id, layer_def)
@@ -163,8 +165,7 @@ class PerfTester:
     def create_testcase(self, test, zoom, layers) -> TestCase:
         layers = [layers] if isinstance(layers, str) else layers
         self.mvt.set_layer_ids(layers)
-        query = self.mvt.generate_query(
-            f'{self.mvt.tile_envelope}($1, xval.x, yval.y)', '$1')
+        query = self.mvt.generate_sql()
         if self.key_column:
             query = f"SELECT mvt FROM ({query}) AS perfdata"
         prefix = 'CAST($1 as int) as z, xval.x as x, yval.y as y,' \


### PR DESCRIPTION
This refactoring will allow future changes to extend bbox per layer,
depending on the buffer size.

For example, we will be able to use ST_TileEnvelope() with the buffer extension
once it is merged.