### PR TITLE
Allow to customize the zoom level used to expire tiles.

### DIFF
--- a/docker/import-osm/README.md
+++ b/docker/import-osm/README.md
@@ -34,6 +34,8 @@ docker run --rm \
 Use standard Postgres [environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) to connect,
 such as `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, `PGPORT`.  All are required except for `PGPORT`.
 
+To customize the zoom level used to expire tiles, use the environnement variable `EXPIRETILES_ZOOM` (default to 14). See the [imposm documentation on tiles expiration](https://imposm.org/docs/imposm3/latest/tutorial.html#expire-tiles).
+
 For backward compatibility the script also supports `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`,
 `POSTGRES_PASSWORD`, and `POSTGRES_PORT`, but they are not recommended.
 

--- a/docker/import-osm/import_diff.sh
+++ b/docker/import-osm/import_diff.sh
@@ -11,7 +11,7 @@ export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
 export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
 export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
-
+export EXPIRETILES_ZOOM="${EXPIRETILES_ZOOM:-14}"
 
 function import_diff() {
     imposm diff \
@@ -20,7 +20,7 @@ function import_diff() {
         -cachedir "$IMPOSM_CACHE_DIR" \
         -diffdir "$IMPORT_DIR" \
         -expiretiles-dir "$IMPORT_DIR" \
-        -expiretiles-zoom 14 \
+        -expiretiles-zoom "$EXPIRETILES_ZOOM" \
         -config "$CONFIG_JSON" \
         "$IMPORT_DIR/changes.osc.gz"
 }

--- a/docker/import-osm/import_update.sh
+++ b/docker/import-osm/import_update.sh
@@ -11,6 +11,7 @@ export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
 export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
 export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
+export EXPIRETILES_ZOOM="${EXPIRETILES_ZOOM:-14}"
 
 function update() {
     imposm run \
@@ -19,7 +20,7 @@ function update() {
         -cachedir "$IMPOSM_CACHE_DIR" \
         -diffdir "$DIFF_DIR" \
         -expiretiles-dir "$TILES_DIR" \
-        -expiretiles-zoom 14 \
+        -expiretiles-zoom "$EXPIRETILES_ZOOM" \
         -config "$CONFIG_JSON"
 }
 


### PR DESCRIPTION
This change is backward compatible. Useful when you need to expire a special zoom level.