### PR TITLE
MVT support 2.4dev postgis ver, rm opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ build-tests: \
     build/mvttile_query_gzip.sql \
     build/mvttile_query_gzip9.sql \
     build/mvttile_query_no_feat_ids.sql \
-    build/mvttile_query_no_tile_env.sql \
+    build/mvttile_query_v2.4.0dev.sql \
+    build/mvttile_query_v2.5.sql \
+    build/mvttile_query_v3.0.sql \
     build/mvttile_query_test_geom.sql \
     build/mvttile_query_test_geom_key.sql \
     build/doc/doc.md \
@@ -88,8 +90,12 @@ build/mvttile_query_gzip9.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --gzip 9                     > build/mvttile_query_gzip9.sql
 build/mvttile_query_no_feat_ids.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --no-feature-ids             > build/mvttile_query_no_feat_ids.sql
-build/mvttile_query_no_tile_env.sql: prepare
-	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --no-tile-envelope           > build/mvttile_query_no_tile_env.sql
+build/mvttile_query_v2.4.0dev.sql: prepare
+	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --postgis-ver 2.4.0dev       > build/mvttile_query_v2.4.0dev.sql
+build/mvttile_query_v2.5.sql: prepare
+	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --postgis-ver 2.5            > build/mvttile_query_v2.5.sql
+build/mvttile_query_v3.0.sql: prepare
+	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --postgis-ver 3.0            > build/mvttile_query_v3.0.sql
 build/mvttile_query_test_geom.sql: prepare
 	$(RUN_CMD) generate-sqltomvt testdata/testlayers/testmaptiles.yaml --query --test-geometry              > build/mvttile_query_test_geom.sql
 build/mvttile_query_test_geom_key.sql: prepare

--- a/bin/debug-mvt
+++ b/bin/debug-mvt
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This is a simple vector tile server that returns a PBF tile for  /tiles/{z}/{x}/{y}.pbf  requests
+Shows content of a single MVT tile as layer tables.
 
 Usage:
   debug-mvt <tileset> <tile_zxy> [--layer=<layer>]... [--exclude-layers]
@@ -42,8 +42,7 @@ from docopt import docopt, DocoptExit
 from tabulate import tabulate
 
 import openmaptiles
-from openmaptiles.language import languages_to_sql
-from openmaptiles.pgutils import show_settings, parse_pg_args
+from openmaptiles.pgutils import parse_pg_args, get_postgis_version
 from openmaptiles.sqltomvt import MvtGenerator
 from openmaptiles.tileset import Tileset
 
@@ -85,16 +84,12 @@ async def main(args):
         messages = []
 
     conn.add_log_listener(connection_logger)
-    pg_settings, postgis_ver = await show_settings(conn, get_ver=True)
-    if postgis_ver < 2.5:
-        raise ValueError('Requires PostGIS version 2.5 or later')
     mvt = MvtGenerator(
         tileset,
         zoom=zoom, x=x, y=y,
         layer_ids=layers,
-        use_feature_id=postgis_ver >= 3,
-        use_tile_envelope=postgis_ver >= 3,
         exclude_layers=exclude_layers,
+        postgis_ver=await get_postgis_version(conn),
     )
 
     def geom_info(expr):
@@ -129,8 +124,10 @@ async def main(args):
             extra_columns=extra_columns,
             languages_sql=None if show_names else f'NULL as _hidden_names_',
         )
+        layer_sql = mvt.generate_layer(layer_def)
         if verbose:
-            print(f"======= Querying layer {layer_id} =======\n{query.strip()}")
+            print(f"\n======= Querying layer {layer_id} =======\n{query.strip()}\n"
+                  f"== MVT SQL\n{layer_sql}")
 
         def field_sorter(v):
             """Move osm_id and geometry fields to the right"""
@@ -155,13 +152,16 @@ async def main(args):
                     del vals['_hidden_names_']
             result.append(vals)
 
+        layer_mvt = len(await conn.fetchval(layer_sql))
+
         if result:
-            info = '(extra name columns are hidden by default) ' if has_names else ''
-            print(f"======= Layer {layer_id} {info}=======")
+            info = ' (extra name columns are hidden by default) ' if has_names else ''
+            print(f"======= Layer {layer_id}{info}: {layer_mvt:,} bytes in MVT =======")
             print_messages()
             print(tabulate(result, headers="keys"))
         else:
-            print(f"======= No data in layer {layer_id}")
+            info = f' (layer data had non-zero {layer_mvt} bytes)' if layer_mvt else ''
+            print(f"======= No data in layer {layer_id}{info}")
             print_messages()
 
 

--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -4,10 +4,10 @@ This script generates a single SQL statement (either as an SQL function or as a 
 to generate a vector tile (MVT) for the given zoom and bounding box.
 
 Usage:
-  generate-sqltomvt <tileset> [--fname <name>]
+  generate-sqltomvt <tileset> [--fname <name>] [--postgis-ver <version>]
                     [--function | --prepared | --query | --psql | --raw]
                     [--layer=<layer>]... [--exclude-layers] [--key]
-                    [--gzip [<gzlevel>]] [--no-feature-ids] [--no-tile-envelope]
+                    [--gzip [<gzlevel>]] [--no-feature-ids]
                     [--test-geometry]
   generate-sqltomvt --help
   generate-sqltomvt --version
@@ -15,6 +15,8 @@ Usage:
   <tileset>        Tileset definition yaml file
 
 Options:
+  -v --postgis-ver=<v>  Which version of PostGIS to target.  [default: 3.0]
+                        This value changes optimizes generated SQL for the specific ver.
   --fname=<name>        Name of the generated function  [default: gettile]
   -f --function         Generate function generation SQL [default]
   -p --prepared         Generate prepared statement SQL
@@ -27,8 +29,6 @@ Options:
   --gzip                If set, compress MVT with gzip, with optional level=0..9.
                         `gzip()` is available from https://github.com/pramsey/pgsql-gzip
   --no-feature-ids      Disable feature ID generation, e.g. from osm_id.
-                        You must use this flag when generating SQL for PostGIS before v3
-  --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
                         You must use this flag when generating SQL for PostGIS before v3
   -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
   --help                Show this screen.
@@ -51,13 +51,13 @@ if __name__ == '__main__':
 
     mvt = MvtGenerator(
         tileset=args['<tileset>'],
+        postgis_ver=args['--postgis-ver'],
         zoom=zoom, x=x, y=y,
         layer_ids=args['--layer'],
         exclude_layers=args['--exclude-layers'],
         key_column=args['--key'],
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
-        use_feature_id=not args['--no-feature-ids'],
-        use_tile_envelope=not args['--no-tile-envelope'],
+        use_feature_id=False if args['--no-feature-ids'] else None,
         test_geometry=args['--test-geometry'],
     )
 

--- a/bin/postserve
+++ b/bin/postserve
@@ -4,7 +4,7 @@ This is a simple vector tile server that returns a PBF tile for  /tiles/{z}/{x}/
 
 Usage:
   postserve <tileset> [--serve=<host>] [--port=<port>] [--key] [--gzip [<gzlevel>]]
-                      [--no-feature-ids] [--no-tile-envelope] [--file=<sql-file>]
+                      [--no-feature-ids] [--file=<sql-file>]
                       [--layer=<layer>]... [--exclude-layers]
                       [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
                       [--user=<user>] [--password=<password>]
@@ -23,8 +23,6 @@ Options:
   --gzip                If set, compress MVT with gzip, with optional level=0..9.
   --no-feature-ids      Disable feature ID generation, e.g. from osm_id.
                         Feature IDS are automatically disabled with PostGIS before v3
-  --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
-                        ST_TileEnvelope() is auto-disabled with PostGIS before v3.
   -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
   -v --verbose          Print additional debugging information
   --help                Show this screen.
@@ -88,7 +86,6 @@ def main(args):
         key_column=args['--key'],
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         disable_feature_ids=args['--no-feature-ids'],
-        disable_tile_envelope=args['--no-tile-envelope'],
         test_geometry=args['--test-geometry'],
         verbose=args.get('--verbose'),
     ).serve()

--- a/bin/test-perf
+++ b/bin/test-perf
@@ -8,7 +8,7 @@ Usage:
               ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
               [--record=<file>] [--compare=<file>] [--buckets=<count>]
               [--key] [--gzip [<gzlevel>]] [--no-color] [--no-feature-ids]
-              [--no-tile-envelope] [--test-geometry] [--verbose]
+              [--test-geometry] [--verbose]
               [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
               [--user=<user>] [--password=<password>]
 
@@ -36,8 +36,6 @@ Options:
   --no-color            Disable ANSI colors
   --no-feature-ids      Disable feature ID generation, e.g. from osm_id.
                         Feature IDS are automatically disabled with PostGIS before v3.
-  --no-tile-envelope    Disable PostGIS 3.0+ ST_TileEnvelope() function.
-                        ST_TileEnvelope() is auto-disabled with PostGIS before v3.
   -v --verbose          Print additional debugging information.
   --help                Show this screen.
   --version             Show version.
@@ -88,7 +86,6 @@ def main(args):
         save_to=args['--record'],
         compare_with=args['--compare'],
         disable_feature_ids=args['--no-feature-ids'],
-        disable_tile_envelope=args['--no-tile-envelope'],
         key_column=args['--key'],
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         verbose=args.get('--verbose'),

--- a/testdata/expected/mvttile_query_v2.4.0dev.sql
+++ b/testdata/expected/mvttile_query_v2.4.0dev.sql
@@ -1,0 +1,6 @@
+SELECT STRING_AGG(mvtl, '') AS mvt FROM (
+  SELECT COALESCE(ST_AsMVT('housenumber', 4096, 'mvtgeometry', t), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(ST_Expand(TileBBox($1, $2, $3), 78271.51696402051/2^$1), $1)) AS t WHERE mvtgeometry IS NOT NULL
+    UNION ALL
+  SELECT COALESCE(ST_AsMVT('enumfield', 4096, 'mvtgeometry', t), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t WHERE mvtgeometry IS NOT NULL
+) AS all_layers
+

--- a/testdata/expected/mvttile_query_v2.5.sql
+++ b/testdata/expected/mvttile_query_v2.5.sql
@@ -1,6 +1,6 @@
 SELECT STRING_AGG(mvtl, '') AS mvt FROM (
   SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(ST_Expand(TileBBox($1, $2, $3), 78271.51696402051/2^$1), $1)) AS t
     UNION ALL
-  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, TileBBox($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(TileBBox($1, $2, $3), $1)) AS t
 ) AS all_layers
 

--- a/testdata/expected/mvttile_query_v3.0.sql
+++ b/testdata/expected/mvttile_query_v3.0.sql
@@ -1,0 +1,6 @@
+SELECT STRING_AGG(mvtl, '') AS mvt FROM (
+  SELECT COALESCE(ST_AsMVT(t, 'housenumber', 4096, 'mvtgeometry'), '') as mvtl FROM (SELECT ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 8, true) AS mvtgeometry, housenumber, NULLIF(tags->'name:en', '') AS "name:en", NULLIF(tags->'name:de', '') AS "name:de", NULLIF(tags->'name:cs', '') AS "name:cs", NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin" FROM layer_housenumber(ST_Expand(ST_TileEnvelope($1, $2, $3), 78271.51696402051/2^$1), $1)) AS t
+    UNION ALL
+  SELECT COALESCE(ST_AsMVT(t, 'enumfield', 4096, 'mvtgeometry', 'osm_id'), '') as mvtl FROM (SELECT osm_id, ST_AsMVTGeom(geometry, ST_TileEnvelope($1, $2, $3), 4096, 0, true) AS mvtgeometry, enumfield FROM layer_enumfields(ST_TileEnvelope($1, $2, $3), $1)) AS t
+) AS all_layers
+


### PR DESCRIPTION
* Added MVT support for the legacy Postgis 2.4dev (current docker image)
* BREAKING: Remove --no-tile-envelope parameter from generate-sqltomvt, postserve, test-perf.
  Now ST_TileEnvelope support is automatically determined from the PG version.
* generate-sqltomvt now supports --postgis-ver param that optimizes
  generated MVT for a specific version
* debug-mvt now prints total MVT layer size
* Added unit tests for 3 versions: 2.4dev, 2.5, 3.0