### PR TITLE
generate-sql: delay mat views, richer decl fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ PYTHONPATH=$PWD python3 bin/generate-imposm3 ../openmaptiles/openmaptiles.yaml
 
 Use `make test` to run all of the tests locally.  The Makefile will build a docker image with all the code, run all tests, and compare the build result with the files in the [testdata/expected](./testdata/expected) dir.
 
-Run `make rebuild-expected` after you modify the output produced by the generation scripts. This will re-create the expected test results to match the actual ones, and make sure the changes are what you want. 
+Run `make rebuild-expected` after you modify the output produced by the generation scripts. This will re-create the expected test results to match the actual ones, and make sure the changes are what you want.
 
 ## Data Concepts
 
@@ -99,12 +99,11 @@ layer:
           subclass: ['school','kindergarten','uni%']
         railway:
           # (subclass='station' AND mapping_key='railway')
-          # OR subclass in ('halt','tram_stop','subway') 
+          # OR subclass in ('halt','tram_stop','subway')
           - __AND__:
               subclass: 'station'
               mapping_key: 'railway'
           - subclass: ['halt', 'tram_stop', 'subway']
-        
 schema:
   - ./building.sql
 datasources:
@@ -127,7 +126,7 @@ SELECT CASE
     WHEN "subclass" IN ('school', 'kindergarten')
         OR "subclass" LIKE 'uni%' THEN 'school'
     WHEN ("subclass" = 'station' AND "mapping_key" = 'railway')
-        OR "subclass" in ('halt','tram_stop','subway') THEN 'railway' 
+        OR "subclass" in ('halt','tram_stop','subway') THEN 'railway'
 END, ...
 ```
 
@@ -199,7 +198,7 @@ Use `postserve <tileset>` to start serving. Use `--help` to get the list of Post
 docker run -it --rm -u $(id -u ${USER}):$(id -g ${USER}) \
     -v "${PWD}:/tileset" --net=host \
     openmaptiles/openmaptiles-tools \
-    postserve openmaptiles.yaml 
+    postserve openmaptiles.yaml
 ```
 
 #### Viewing dynamic tiles
@@ -262,7 +261,7 @@ Uses tileset definition to create a PostgreSQL
  [create function](https://www.postgresql.org/docs/9.1/sql-createfunction.html) SQL code
  to generate an entire vector tile in the Mapbox Vector Tile format with a single `getTile(z,x,y)` query
  using PostGIS MVT support.
- 
+
 Use `--help` to get all parameters.
 
 **NOTE:** Current [openmaptiles/postgis](https://github.com/openmaptiles/postgis) image (v2.9 and before) has incorrect
@@ -353,7 +352,7 @@ mbtiles-tools ./data/tiles.mbtiles meta-all
 ```
 
 ### Add simple metadata to mbtiles file
-Updates `metadata` table in the mbtiles file. See [mbtiles-tools](#mbtiles-file-tools) for other tools. 
+Updates `metadata` table in the mbtiles file. See [mbtiles-tools](#mbtiles-file-tools) for other tools.
 Example:
 ```
 generate-metadata ./data/tiles.mbtiles

--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 """
 Usage:
-  generate-sql <tileset> [--dir <dir>]
+  generate-sql <tileset> [--dir <dir>] [--nodata]
   generate-sql --help
   generate-sql --version
 
 Options:
-  -d --dir=<dir>      Output multiple sql files into this directory. Prints to STDOUT by default.
+  -d --dir=<dir>      Output multiple sql files into this directory.
+                      Without the -d parameter, prints everything to STDOUT.
+  -n --nodata         If set, materialized views are created without the data.
+                      Use refresh-views utility to refresh views after creation.
   --help              Show this screen.
   --version           Show version.
 """
@@ -18,11 +21,13 @@ from openmaptiles.sql import collect_sql
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
+    nodata = args['--nodata']
+    tileset = args['<tileset>']
     if not args['--dir']:
-        print(collect_sql(args['<tileset>']))
+        print(collect_sql(tileset, nodata=nodata))
     else:
         run_first, parallel_sql, run_last = collect_sql(
-            args['<tileset>'], parallel=True)
+            tileset, nodata=nodata, parallel=True)
 
         path = Path(args['--dir'])
         path.mkdir(parents=True, exist_ok=True)

--- a/testdata/expected/parallel_sql/parallel/001.sql
+++ b/testdata/expected/parallel_sql/parallel/001.sql
@@ -2,12 +2,27 @@ DO $$ BEGIN RAISE NOTICE 'Processing layer enumfield'; END$$;
 
 CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
     SELECT CASE
-        WHEN "natural"='bare_rock' THEN 'rock'
-        WHEN "natural"='grassland'
+        WHEN "natural" = 'bare_rock' THEN 'rock'
+        WHEN "natural" = 'grassland'
             OR "landuse" IN ('grass', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
             OR "landuse" LIKE 'meadow%'
             THEN 'grass'
-        ELSE NULL
+        WHEN "subclass" IN ('school', 'kindergarten')
+            OR "subclass" LIKE 'uni%'
+            THEN 'school'
+        WHEN ("subclass" = 'station' AND "mapping_key" = 'railway')
+            OR "subclass" IN ('halt', 'tram_stop', 'subway')
+            THEN 'railway'
+        WHEN "field1" = 'a1fld1'
+            AND ("field2" IN ('a1fld2a', 'a1fld2c') OR "field2" LIKE '%a1fld2b%')
+            AND "field3" = 'a1fld3'
+            THEN 'andfield'
+        WHEN "fld1" = 'lf1'
+            OR ("fld2" IN ('lf2a', 'lf2b') OR "fld3" = 'lf3')
+            OR ("fld4" = 'lf4' OR "fld5" IN ('lf5a', 'lf5b') OR "fld5" LIKE 'lf5c%')
+            OR ("fld6" = 'lf6' AND ("fld7" IN ('lf7a', 'lf7b') OR "fld7" LIKE 'lf7c%'))
+            OR ("fld8" = 'lf8' AND ("fld9" IN ('lf9a', 'lf9b') OR "fld10" = 'lf10') AND ("fld11" = 'lf11' OR "fld12" IN ('lf12a', 'lf12b') OR "fld12" LIKE 'lf12c%'))
+            THEN 'listfield'
 END;
 $$ LANGUAGE SQL IMMUTABLE;
 

--- a/testdata/expected/sql.sql
+++ b/testdata/expected/sql.sql
@@ -24,12 +24,27 @@ DO $$ BEGIN RAISE NOTICE 'Processing layer enumfield'; END$$;
 
 CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
     SELECT CASE
-        WHEN "natural"='bare_rock' THEN 'rock'
-        WHEN "natural"='grassland'
+        WHEN "natural" = 'bare_rock' THEN 'rock'
+        WHEN "natural" = 'grassland'
             OR "landuse" IN ('grass', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground')
             OR "landuse" LIKE 'meadow%'
             THEN 'grass'
-        ELSE NULL
+        WHEN "subclass" IN ('school', 'kindergarten')
+            OR "subclass" LIKE 'uni%'
+            THEN 'school'
+        WHEN ("subclass" = 'station' AND "mapping_key" = 'railway')
+            OR "subclass" IN ('halt', 'tram_stop', 'subway')
+            THEN 'railway'
+        WHEN "field1" = 'a1fld1'
+            AND ("field2" IN ('a1fld2a', 'a1fld2c') OR "field2" LIKE '%a1fld2b%')
+            AND "field3" = 'a1fld3'
+            THEN 'andfield'
+        WHEN "fld1" = 'lf1'
+            OR ("fld2" IN ('lf2a', 'lf2b') OR "fld3" = 'lf3')
+            OR ("fld4" = 'lf4' OR "fld5" IN ('lf5a', 'lf5b') OR "fld5" LIKE 'lf5c%')
+            OR ("fld6" = 'lf6' AND ("fld7" IN ('lf7a', 'lf7b') OR "fld7" LIKE 'lf7c%'))
+            OR ("fld8" = 'lf8' AND ("fld9" IN ('lf9a', 'lf9b') OR "fld10" = 'lf10') AND ("fld11" = 'lf11' OR "fld12" IN ('lf12a', 'lf12b') OR "fld12" LIKE 'lf12c%'))
+            THEN 'listfield'
 END;
 $$ LANGUAGE SQL IMMUTABLE;
 

--- a/testdata/testlayers/enumfield/enumfield.sql
+++ b/testdata/testlayers/enumfield/enumfield.sql
@@ -1,6 +1,5 @@
 CREATE OR REPLACE FUNCTION map_landuse_class("natural" VARCHAR, landuse VARCHAR) RETURNS TEXT AS $$
     SELECT CASE
         %%FIELD_MAPPING: class %%
-        ELSE NULL
 END;
 $$ LANGUAGE SQL IMMUTABLE;

--- a/testdata/testlayers/enumfield/enumfield.yaml
+++ b/testdata/testlayers/enumfield/enumfield.yaml
@@ -14,9 +14,41 @@ layer:
           natural: 'grassland'
           # Anything with % should use 'LIKE' instead of equality
           landuse: ['grass', 'meadow%', 'allotments', 'grassland', 'park', 'village_green', 'recreation_ground']
+        school:
+          subclass: ['school','kindergarten','uni%']
+        railway:
+          - __AND__:
+              subclass: 'station'
+              mapping_key: 'railway'
+          - subclass: ['halt', 'tram_stop', 'subway']
+        andfield:
+          __AND__:
+            field1: 'a1fld1'
+            field2: ['a1fld2a', '%a1fld2b%', 'a1fld2c']
+            field3: 'a1fld3'
+        listfield:
+          - fld1: lf1
+          - fld2: ['lf2a', 'lf2b']
+            fld3: lf3
+          - __OR__:
+              fld4: lf4
+              fld5: ['lf5a', 'lf5b', 'lf5c%']
+          - __AND__:
+              fld6: lf6
+              fld7: ['lf7a', 'lf7b', 'lf7c%']
+          - __AND__:
+            - fld8: lf8
+            - fld9: ['lf9a', 'lf9b']
+              fld10: lf10
+            - __OR__:
+                fld11: lf11
+                fld12: ['lf12a', 'lf12b', 'lf12c%']
         # These options are not auto-generated
-        other1: {}
-        other2: false
+        other_null:
+        other_obj: {}
+        other_false: false
+        other_true: true
+        other_str: 'str'
   datasource:
     geometry_field: geometry
     key_field: osm_id


### PR DESCRIPTION
* Support for `/* DELAY_MATERIALIZED_VIEW_CREATION */` parameter,
  allowing materialized views to be created `WITH NO DATA`
* Support for complex boolean expressions when declaring OSM value mappings:

```
school:
  # subclass IN ('school','kindergarten') OR subclass LIKE 'uni%'
  subclass: ['school','kindergarten','uni%']
railway:
  # (subclass='station' AND mapping_key='railway')
  # OR subclass in ('halt','tram_stop','subway')
  - __AND__:
      subclass: 'station'
      mapping_key: 'railway'
  - subclass: ['halt', 'tram_stop', 'subway']
```