### PR TITLE
New import-borders tool imports PBF->DB directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,48 @@ WORKDIR /usr/src/app
 ENV PATH="/usr/src/app:${PATH}" \
     VT_UTIL_DIR=/opt/postgis-vt-util \
     OMT_UTIL_DIR=/usr/src/app/sql \
-    SQL_DIR=/sql
+    SQL_DIR=/sql \
+    OSMBORDER_REV=e3ae8f7a2dcdcd6dc80abab4679cb5edb7dc6fa5 \
+    PGFUTTER_VERSION="v1.2" \
+    WGET="wget --quiet --progress=bar:force:noscroll --show-progress"
 
 ARG PG_MAJOR=12
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && /bin/bash -c 'source /etc/os-release && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list' \
-    && apt-get update \
-    && apt-get install  -y --no-install-recommends \
+    && /bin/bash -c 'source /etc/os-release && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME?}-pgdg main ${PG_MAJOR?}" > /etc/apt/sources.list.d/pgdg.list' \
+    && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install  -y --no-install-recommends \
         graphviz  `# used by layer mapping graphs` \
         sqlite3 \
         gdal-bin  `# installs ogr2ogr` \
-        postgresql-client-${PG_MAJOR} \
-    && rm -rf /var/lib/apt/lists/
+        postgresql-client-${PG_MAJOR?} \
+        \
+        `# tools to build osmborder` \
+        build-essential \
+        ca-certificates \
+        cmake \
+        git \
+        libosmium2-dev \
+        wget \
+        zlib1g-dev \
+        \
+    && rm -rf /var/lib/apt/lists/ \
+    && (  `# Build osmborder` \
+        git clone https://github.com/pnorman/osmborder.git /usr/src/osmborder \
+        && cd /usr/src/osmborder \
+        && git checkout ${OSMBORDER_REV?} \
+        && mkdir -p /usr/src/osmborder/build \
+        && cd /usr/src/osmborder/build \
+        && cmake .. \
+        && make \
+        && make install \
+        && rm -rf /usr/src/osmborder \
+       ) \
+    && (  `# Set up pgfutter` \
+        $WGET -O /usr/local/bin/pgfutter \
+           "https://github.com/lukasmartinelli/pgfutter/releases/download/${PGFUTTER_VERSION}/pgfutter_linux_amd64" \
+        && chmod +x /usr/local/bin/pgfutter \
+       )
 
 # Copy requirements.txt first to avoid pip install on every code change
 COPY ./requirements.txt .
@@ -28,8 +57,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 RUN curl -OL https://raw.githubusercontent.com/mapbox/postgis-vt-util/v1.0.0/postgis-vt-util.sql && \
-    mkdir -p "$VT_UTIL_DIR" && \
-    mv postgis-vt-util.sql ${VT_UTIL_DIR}/ && \
+    mkdir -p "${VT_UTIL_DIR?}" && \
+    mv postgis-vt-util.sql ${VT_UTIL_DIR?}/ && \
     mv bin/* . && \
     rm -rf bin && \
     rm requirements.txt

--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ You need to provide PostgreSQL database connection settings before generating th
 generate-tm2source <tileset> --host="localhost" --port=5432 --database="osm" --user="osm" --password="osm"
 ```
 
+### Import OSM Borders
+
+The **import-borders** script will take the first PBF file from the `/import` dir (by default), extract borders with [osmborder tool](https://github.com/pnorman/osmborder), and import resulting CSV file into the database as osm_border_linestring table (by default).
+
+This utility requires PostgreSQL's PG* environment variables.
+
 ## Importing into Postgres
 The `import-sql` script can execute a single SQL file in Postgres when the file is given as the first parameter.
 

--- a/bin/import-borders
+++ b/bin/import-borders
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+: "${IMPORT_DIR:=/import}"
+# Do not use .pbf extension to avoid accidental conflict with the original pbf with multiple runs
+: "${BORDERS_PBF_FILE:="$IMPORT_DIR/borders/filtered.pbf"}"
+: "${BORDERS_CSV_FILE:="$IMPORT_DIR/borders/lines.csv"}"
+
+# For backward compatibility, allow both PG* and POSTGRES_* forms,
+# with the non-standard POSTGRES_* form taking precedence.
+# An error will be raised if neither form is given, except for the PGPORT
+export PGHOST="${POSTGRES_HOST:-${PGHOST?}}"
+export PGDATABASE="${POSTGRES_DB:-${PGDATABASE?}}"
+export PGUSER="${POSTGRES_USER:-${PGUSER?}}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-${PGPASSWORD?}}"
+export PGPORT="${POSTGRES_PORT:-${PGPORT:-5432}}"
+
+: "${TABLE_NAME:=osm_border_linestring}"
+
+
+# First argument is the PBF file to parse.
+# If there are no arguments, searches for the first *.pbf file in the $IMPORT_DIR
+if [[ $# -eq 0 ]]; then
+  if [ "$(ls -A "$IMPORT_DIR"/*.pbf 2> /dev/null)" ]; then
+    for IMPORT_PBF_FILE in "$IMPORT_DIR"/*.pbf; do
+      break
+    done
+  else
+    echo "No PBF files found in the $IMPORT_DIR dir."
+    exit 1
+  fi
+else
+  IMPORT_PBF_FILE="$1"
+fi
+
+
+echo "Filtering $IMPORT_PBF_FILE into $BORDERS_PBF_FILE"
+mkdir -p "$(dirname "${BORDERS_PBF_FILE?}")"
+rm -rf "${BORDERS_PBF_FILE?}"
+osmborder_filter -o "$BORDERS_PBF_FILE" "$IMPORT_PBF_FILE"
+
+
+echo "Creating a CSV borders file $BORDERS_CSV_FILE"
+mkdir -p "$(dirname "${BORDERS_CSV_FILE?}")"
+rm -rf "${BORDERS_CSV_FILE?}"
+osmborder -o "$BORDERS_CSV_FILE" "$BORDERS_PBF_FILE"
+
+
+echo "Importing $BORDERS_CSV_FILE into $PGHOST:$PGPORT/$PGDATABASE as table $TABLE_NAME..."
+psql -c "DROP TABLE IF EXISTS $TABLE_NAME CASCADE;" \
+     -c "CREATE TABLE $TABLE_NAME (osm_id bigint, admin_level int, dividing_line bool, disputed bool, maritime bool, geometry Geometry(LineString, 3857));" \
+     -c "CREATE INDEX ON $TABLE_NAME USING gist (geometry);"
+pgfutter \
+    --schema "public" \
+    --host "$PGHOST" \
+    --port "$PGPORT" \
+    --dbname "$PGDATABASE" \
+    --username "$PGUSER" \
+    --pass "$PGPASSWORD" \
+    --table "$TABLE_NAME" \
+  csv \
+    --fields "osm_id,admin_level,dividing_line,disputed,maritime,geometry" \
+    --delimiter $'\t' \
+  "$BORDERS_CSV_FILE"


### PR DESCRIPTION
Added a new import-borders script will take the first PBF file from the `/import` dir, extract borders with [osmborder tool](https://github.com/pnorman/osmborder), and import resulting CSV file into the database as osm_border_linestring table.

This means we will no longer need border snapshots stored in the releases,
and we can delete both `generate-osmborder` and `import-osmborder` docker images.