### PR TITLE
Fix legacy import-wikidata docker image

### DIFF
--- a/docker/import-wikidata/Dockerfile
+++ b/docker/import-wikidata/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY . /usr/src/app
-RUN pip install .
+RUN pip install . \
+    && mv bin/* .
 
 WORKDIR /import
 VOLUME /import


### PR DESCRIPTION
Move docker/import-wikidata/bin/import-wikidata script to root
during the docker build to override the new import-wikidata script
that was added in the root bin.