### PR TITLE
SQL testing framework, omt_is_latin() tests

### DIFF
--- a/test-sql/omt_is_latin.sql
+++ b/test-sql/omt_is_latin.sql
@@ -1,0 +1,12 @@
+SELECT omt_is_latin('') as empty_str;
+SELECT omt_is_latin(' ') as space;
+SELECT omt_is_latin('abc_xyz') as abc_xyz;
+SELECT omt_is_latin('ABC_XYZ') as ABC_XYZ;
+SELECT omt_is_latin('0123456789') as digits;
+
+-- Extended Latin from https://en.wikipedia.org/wiki/Latin_Extended_Additional#Compact_table
+SELECT omt_is_latin('ḀḁḂḃḄḅḆḇḈḉḊḋḌḍḎḏḐḑḒḓḔḕḖḗḘḙḚḛḜḝḞḟḠḡḢḣḤḥḦḧḨḩḪḫḬḭḮḯḰḱḲḳḴḵḶḷḸḹḺḻḼḽḾḿṀṁṂṃṄṅṆṇṈṉṊṋṌṍṎṏṐṑṒṓṔṕṖṗṘṙṚṛṜṝṞṟṠṡṢṣṤṥṦṧṨṩṪṫṬṭṮṯṰṱṲṳṴṵṶṷṸṹṺṻṼṽṾṿẀẁẂẃẄẅẆẇẈẉẊẋẌẍẎẏẐẑẒẓẔẕẖẗẘẙẚẛẜẝẞẟẠạẢảẤấẦầẨẩẪẫẬậẮắẰằẲẳẴẵẶặẸẹẺẻẼẽẾếỀềỂểỄễỆệỈỉỊịỌọỎỏỐốỒồỔổỖỗỘộỚớỜờỞởỠỡỢợỤụỦủỨứỪừỬửỮữỰựỲỳỴỵỶỷỸỹỺỻỼỽỾỿ') as ext_latin;
+
+-- Russian
+SELECT omt_is_latin('привет') as russian_lc;
+SELECT omt_is_latin('ПРИВЕТ') as russian_uc;

--- a/test-sql/test-sql-entrypoint.sh
+++ b/test-sql/test-sql-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+echo "$@"
+echo "-----------------------start"
+cp /omt/test-sql/test-sql.sh /docker-entrypoint-initdb.d/zzzzzzzzzzzzzzzzzzz.sh
+docker-entrypoint.sh postgres
+echo "-----------------------end"

--- a/test-sql/test-sql.sh
+++ b/test-sql/test-sql.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+echo "++++++++++++++++++++++++"
+echo "Importing /sql dir"
+echo "++++++++++++++++++++++++"
+for sql_file in /omt/sql/*.sql; do
+  echo "Importing $sql_file..."
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --file "$sql_file"
+done
+
+echo "++++++++++++++++++++++++"
+echo "Running OMT SQL tests"
+echo "++++++++++++++++++++++++"
+
+for sql_file in /omt/test-sql/*.sql; do
+  # Ensure output file can be deleted though it is owned by root
+  out_file="/omt/build/$(basename "$sql_file").out"
+  truncate --size 0 "$out_file"
+  chmod 666 "$out_file"
+  echo "Executing $sql_file and recording results in $out_file"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" --file "$sql_file" >> "$out_file"
+done
+
+
+echo "Done with the testing"
+# Stopping PostgreSQL by intentionally exiting with an error
+exit 1

--- a/testdata/expected/omt_is_latin.sql.out
+++ b/testdata/expected/omt_is_latin.sql.out
@@ -1,0 +1,40 @@
+ empty_str 
+-----------
+ t
+(1 row)
+
+ space 
+-------
+ t
+(1 row)
+
+ abc_xyz 
+---------
+ t
+(1 row)
+
+ abc_xyz 
+---------
+ t
+(1 row)
+
+ digits 
+--------
+ t
+(1 row)
+
+ ext_latin 
+-----------
+ t
+(1 row)
+
+ russian_lc 
+------------
+ f
+(1 row)
+
+ russian_uc 
+------------
+ f
+(1 row)
+


### PR DESCRIPTION
Runs SQL scripts in the /test-sql dir using postgis image.
If the output of the script is different from expected, will raise an error.

Uses the same `make test` as before.

Also adds an example unit test for omt_is_latin()

This will simplify testing https://github.com/openmaptiles/openmaptiles/pull/728 
cc: @jsanz