### PR TITLE
Updates postgis-vt-util references to point to OpenMapTiles fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY ./requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN curl -OL https://raw.githubusercontent.com/openmaptiles/postgis-vt-util/master/postgis-vt-util.sql && \
+RUN curl -OL https://raw.githubusercontent.com/openmaptiles/postgis-vt-util/v2.0.0/postgis-vt-util.sql && \
     mkdir -p "${VT_UTIL_DIR?}" && \
     mv postgis-vt-util.sql "${VT_UTIL_DIR?}/" && \
     mv bin/* . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,9 @@ COPY ./requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN curl -OL https://raw.githubusercontent.com/mapbox/postgis-vt-util/v1.0.0/postgis-vt-util.sql && \
+RUN curl -OL https://raw.githubusercontent.com/openmaptiles/postgis-vt-util/master/postgis-vt-util.sql && \
     mkdir -p "${VT_UTIL_DIR?}" && \
-    mv postgis-vt-util.sql ${VT_UTIL_DIR?}/ && \
+    mv postgis-vt-util.sql "${VT_UTIL_DIR?}/" && \
     mv bin/* . && \
     rm -rf bin && \
     rm requirements.txt

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The `import-sql` script can execute a single SQL file in Postgres when the file 
 
 If ran without any arguments, `import-sql` executes all of the following:
 * SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
-* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://raw.githubusercontent.com/openmaptiles/postgis-vt-util/master/postgis-vt-util.sql) helper functions.
+* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/openmaptiles/postgis-vt-util/blob/master/postgis-vt-util.sql) helper functions.
 * SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. If this directory contains `parallel/` subdirectory, `import-sql` will assume the parallel/*.sql files are safe to execute in parallel, up to `MAX_PARALLEL_PSQL` at a time (defaults to 5). The script will also execute `run_first.sql` before, and `run_last.sql` after the files in `parallel/` dir (if they exist).
 
 Generating and importing SQL could be done in a single step with `&&`, e.g.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The `import-sql` script can execute a single SQL file in Postgres when the file 
 
 If ran without any arguments, `import-sql` executes all of the following:
 * SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
-* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/mapbox/postgis-vt-util/blob/v1.0.0/postgis-vt-util.sql) helper functions.
+* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://raw.githubusercontent.com/openmaptiles/postgis-vt-util/master/postgis-vt-util.sql) helper functions.
 * SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. If this directory contains `parallel/` subdirectory, `import-sql` will assume the parallel/*.sql files are safe to execute in parallel, up to `MAX_PARALLEL_PSQL` at a time (defaults to 5). The script will also execute `run_first.sql` before, and `run_last.sql` after the files in `parallel/` dir (if they exist).
 
 Generating and importing SQL could be done in a single step with `&&`, e.g.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The `import-sql` script can execute a single SQL file in Postgres when the file 
 
 If ran without any arguments, `import-sql` executes all of the following:
 * SQL files from `$OMT_UTIL_DIR`  -  by default contains the [sql/language.sql](./sql/language.sql) script.
-* SQL files from `$VT_UTIL_DIR`  - by default contains Mapbox's [postgis-vt-util.sql](https://github.com/openmaptiles/postgis-vt-util/blob/master/postgis-vt-util.sql) helper functions.
+* SQL files from `$VT_UTIL_DIR`  - by default contains OMT fork of the Mapbox's [postgis-vt-util.sql](https://github.com/openmaptiles/postgis-vt-util) helper functions.
 * SQL files from `$SQL_DIR`  - defaults to `/sql` -- this volume is empty initially, but should contain build results of running other generation scripts. If this directory contains `parallel/` subdirectory, `import-sql` will assume the parallel/*.sql files are safe to execute in parallel, up to `MAX_PARALLEL_PSQL` at a time (defaults to 5). The script will also execute `run_first.sql` before, and `run_last.sql` after the files in `parallel/` dir (if they exist).
 
 Generating and importing SQL could be done in a single step with `&&`, e.g.

--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -3,12 +3,12 @@ from .tileset import Tileset
 
 
 def zres(pixel_scale, zoom):
-    # See https://github.com/mapbox/postgis-vt-util/blob/master/src/ZRes.sql
+    # See https://github.com/openmaptiles/postgis-vt-util/blob/master/src/ZRes.sql
     return 40075016.6855785 / ((1.0 * pixel_scale) * 2 ** zoom)
 
 
 def call_zres(pixel_scale, match):
-    # See https://github.com/mapbox/postgis-vt-util/blob/master/src/ZRes.sql
+    # See https://github.com/openmaptiles/postgis-vt-util/blob/master/src/ZRes.sql
     return str(zres(float(pixel_scale), float(match.group(0)[4:6])))
 
 


### PR DESCRIPTION
This PR updates references to `postgis-vt-util.sql` script to point to [OpenMaptiles/postgis-vt-util](https://github.com/openmaptiles/postgis-vt-util) `master` branch. Eventually, I think we should make new releases of the script.