### PR TITLE
Fix import-water image, simplify images

### DIFF
--- a/docker/import-lakelines/Dockerfile
+++ b/docker/import-lakelines/Dockerfile
@@ -1,15 +1,13 @@
 # Use a separate docker for downloading to minimize final docker image
-# BASE_TAG will be injected by the dockerhub auto-build environment
-ARG BASE_TAG=latest
-FROM openmaptiles/openmaptiles-tools:${BASE_TAG} as downloader
+FROM bash as downloader
 
 WORKDIR /
-RUN wget --quiet -L https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
+RUN wget --quiet https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
 
 
 FROM osgeo/gdal:alpine-normal-3.0.2
-ENV IMPORT_DIR=/import \
-    LAKELINES_GEOJSON=/data/import/lake_centerline.geojson
+ENV IMPORT_DIR=/import
+ENV LAKELINES_GEOJSON=/data/import/lake_centerline.geojson
 
 COPY --from=downloader /lake_centerline.geojson $IMPORT_DIR/
 WORKDIR /usr/src/app

--- a/docker/import-lakelines/hooks/build
+++ b/docker/import-lakelines/hooks/build
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-docker build \
-  --build-arg "BASE_TAG=$DOCKER_TAG" \
-  -t "$IMAGE_NAME" \
-  -f "$DOCKERFILE_PATH" \
-  .

--- a/docker/import-natural-earth/Dockerfile
+++ b/docker/import-natural-earth/Dockerfile
@@ -1,11 +1,10 @@
 # Use a separate docker for downloading to minimize final docker image
-# BASE_TAG will be injected by the dockerhub auto-build environment
-ARG BASE_TAG=latest
-FROM openmaptiles/openmaptiles-tools:${BASE_TAG} as downloader
+FROM bash as downloader
 
 WORKDIR /usr/src/app-ne
 COPY clean-natural-earth.sh .
-RUN wget --quiet http://naciscdn.org/naturalearth/packages/natural_earth_vector.sqlite.zip && \
+RUN apk add --no-cache sqlite && \
+    wget --quiet http://naciscdn.org/naturalearth/packages/natural_earth_vector.sqlite.zip && \
     unzip -oj natural_earth_vector.sqlite.zip -d . '*natural_earth_vector.sqlite' && \
     NATURAL_EARTH_DB=./natural_earth_vector.sqlite ./clean-natural-earth.sh
 
@@ -13,8 +12,8 @@ RUN wget --quiet http://naciscdn.org/naturalearth/packages/natural_earth_vector.
 FROM osgeo/gdal:alpine-normal-3.0.2
 LABEL maintainer="YuriAstrakhan@gmail.com"
 
-ENV IMPORT_DATA_DIR=/import \
-    NATURAL_EARTH_DB=/import/natural_earth_vector.sqlite
+ENV IMPORT_DATA_DIR=/import
+ENV NATURAL_EARTH_DB=/import/natural_earth_vector.sqlite
 
 COPY --from=downloader /usr/src/app-ne/natural_earth_vector.sqlite ${IMPORT_DATA_DIR}/
 WORKDIR /usr/src/app

--- a/docker/import-natural-earth/hooks/build
+++ b/docker/import-natural-earth/hooks/build
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-docker build \
-  --build-arg "BASE_TAG=$DOCKER_TAG" \
-  -t "$IMAGE_NAME" \
-  -f "$DOCKERFILE_PATH" \
-  .

--- a/docker/import-water/Dockerfile
+++ b/docker/import-water/Dockerfile
@@ -1,7 +1,5 @@
 # Use a separate docker for downloading to minimize final docker image
-# BASE_TAG will be injected by the dockerhub auto-build environment
-ARG BASE_TAG=latest
-FROM openmaptiles/openmaptiles-tools:${BASE_TAG} as downloader
+FROM bash as downloader
 
 ENV IMPORT_DATA_DIR=/import
 RUN mkdir -p /import \
@@ -11,12 +9,11 @@ RUN mkdir -p /import \
     && rm water-polygons-split-3857.zip
 
 
-FROM osgeo/gdal:alpine-normal-3.0.2
+FROM osgeo/gdal:alpine-normal-3.0.3
 LABEL maintainer="YuriAstrakhan@gmail.com"
 
-ENV IMPORT_DATA_DIR=/import \
-    WATER_POLYGONS_FILE="${IMPORT_DATA_DIR}/water_polygons.shp"
-
+ENV IMPORT_DATA_DIR=/import
+ENV WATER_POLYGONS_FILE="${IMPORT_DATA_DIR}/water_polygons.shp"
 
 COPY --from=downloader "$IMPORT_DATA_DIR"/* ${IMPORT_DATA_DIR}/
 

--- a/docker/import-water/hooks/build
+++ b/docker/import-water/hooks/build
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-docker build \
-  --build-arg "BASE_TAG=$DOCKER_TAG" \
-  -t "$IMAGE_NAME" \
-  -f "$DOCKERFILE_PATH" \
-  .


### PR DESCRIPTION
* Using tools as a temp downloader image had more problems
  than it solved, so switching to a simple "bash" as the base.
  * this means no more need for the build hooks
* upgrade ogr2ogr 3.0.2 -> 3.0.3
* fixed ENV vars having issues with cross-dependency