### PR TITLE
Fix regression in tm2source key_field_as_attribute

### DIFF
--- a/openmaptiles/tmsource.py
+++ b/openmaptiles/tmsource.py
@@ -31,11 +31,10 @@ def generate_tm2source(tileset_filename, db_params):
 def generate_layer(layer: Layer, db_params):
     key_field = layer.key_field or ''
     if key_field == '':
-        #      column number 4 is out of range 0..3
-        # /usr/local/lib/node_modules/tilelive/bin/tilelive-copy:100
-        # Error: basic_string::_S_construct null not valid
-        #     at Error (native)
-        kf_as_attr = ''  # weird Mapnik expectation, throws an error otherwise
+        # weird Mapnik expectation. Use '', otherwise Mapnik throws an error:
+        #   column number 4 is out of range 0..3
+        #   Error: basic_string::_S_construct null not valid
+        kf_as_attr = ''
     else:
         kf_as_attr = layer.key_field_as_attribute
     return {

--- a/openmaptiles/tmsource.py
+++ b/openmaptiles/tmsource.py
@@ -29,6 +29,15 @@ def generate_tm2source(tileset_filename, db_params):
 
 
 def generate_layer(layer: Layer, db_params):
+    key_field = layer.key_field or ''
+    if key_field == '':
+        #      column number 4 is out of range 0..3
+        # /usr/local/lib/node_modules/tilelive/bin/tilelive-copy:100
+        # Error: basic_string::_S_construct null not valid
+        #     at Error (native)
+        kf_as_attr = ''  # weird Mapnik expectation, throws an error otherwise
+    else:
+        kf_as_attr = layer.key_field_as_attribute
     return {
         'id': layer.id,
         'srs': layer.srs,
@@ -38,8 +47,8 @@ def generate_layer(layer: Layer, db_params):
         'Datasource': {
             'extent': [-20037508.34, -20037508.34, 20037508.34, 20037508.34],
             'geometry_field': layer.geometry_field,
-            'key_field': layer.key_field or '',
-            'key_field_as_attribute': layer.key_field_as_attribute,
+            'key_field': key_field,
+            'key_field_as_attribute': kf_as_attr,
             'max_size': layer.max_size,
             'port': db_params.port,
             'srid': layer.srid,

--- a/testdata/expected/tm2source.yml
+++ b/testdata/expected/tm2source.yml
@@ -9,7 +9,7 @@ Layer:
     geometry_field: geometry
     host: pghost
     key_field: ''
-    key_field_as_attribute: false
+    key_field_as_attribute: ''
     max_size: 512
     password: pgpswd
     port: 5432


### PR DESCRIPTION
When key_field is '', key_field_as_attribute should be set to ''
Otherwise Mapnik causes an error:

  column number 4 is out of range 0..3
 /usr/local/lib/node_modules/tilelive/bin/tilelive-copy:100
 Error: basic_string::_S_construct null not valid
     at Error (native)