### PR TITLE
Rm dup etldoc

### DIFF
--- a/tests/expected/devdoc/etl_housenumber
+++ b/tests/expected/devdoc/etl_housenumber
@@ -2,7 +2,6 @@ digraph G {
 	graph [rankdir=LR]
 imposm3 -> osm_housenumber_point
 osm_housenumber_point -> osm_housenumber_point
-layer_housenumber[shape=record fillcolor=lightpink, style="rounded,filled",
-label="layer_housenumber | <z14_> z14_" ] ;
+layer_housenumber[shape=record fillcolor=lightpink, style="rounded,filled", label="layer_housenumber | <z14_> z14_" ] ;
 osm_housenumber_point -> layer_housenumber:z14_
 }

--- a/tests/expected/devdoc/housenumber/etl_diagram
+++ b/tests/expected/devdoc/housenumber/etl_diagram
@@ -2,7 +2,6 @@ digraph G {
 	graph [rankdir=LR]
 imposm3 -> osm_housenumber_point
 osm_housenumber_point -> osm_housenumber_point
-layer_housenumber[shape=record fillcolor=lightpink, style="rounded,filled",
-label="layer_housenumber | <z14_> z14_" ] ;
+layer_housenumber[shape=record fillcolor=lightpink, style="rounded,filled", label="layer_housenumber | <z14_> z14_" ] ;
 osm_housenumber_point -> layer_housenumber:z14_
 }

--- a/tests/testlayers/housenumber/mapping.yaml
+++ b/tests/testlayers/housenumber/mapping.yaml
@@ -1,6 +1,8 @@
 
 tables:
 
+  # --- test that duplicate items are removed
+  # 	etldoc: imposm3  ->	 osm_housenumber_point
   # etldoc: imposm3 -> osm_housenumber_point
   housenumber_point:
     type: geometry


### PR DESCRIPTION
Make graphs cleaner by removing duplicate lines between the same nodes.
Also convert multiple spaces/tabs into a single space.