### PR TITLE
Upgrade to latest PostGIS 2.4 version to fix errors during auto-analyze

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -1,8 +1,8 @@
 FROM postgres:9.6
 MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
-ENV POSTGIS_MAJOR=2.4dev \
-    POSTGIS_VERSION=2.4dev \
-    GEOS_VERSION=3.6.0
+ENV POSTGIS_MAJOR=2.4 \
+    POSTGIS_VERSION=2.4.8 \
+    GEOS_VERSION=3.6.4
 
 RUN apt-get -qq -y update \
  && apt-get -qq -y --no-install-recommends install \
@@ -62,9 +62,9 @@ RUN apt-get -qq -y update \
  && cd /opt/ \
  && git clone https://github.com/postgis/postgis.git \
  && cd postgis \
- && git reset --hard ff0a844e606622f45841fc25221bbaa136ed1001 \
+ && git reset --hard $POSTGIS_VERSION \
  && ./autogen.sh \
- && ./configure CFLAGS="-O0 -Wall" \
+ && ./configure CFLAGS="-Wall" \
  && make \
  && make install \
  && ldconfig \

--- a/docker/postgis/README.md
+++ b/docker/postgis/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.6.0 and PostGIS 2.4dev
+# PostgreSQL with GEOS 3.6.4 and PostGIS 2.4.8
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.6.0 and PostGIS 2.3.1.
+A custom PostgreSQL Docker image based off GEOS 3.6.4 and PostGIS 2.4.8.
 
 ## Usage
 


### PR DESCRIPTION
Here are errors I got with the current "openmaptiles/postgis" image (based on PostgreSQL 9.6.16) after running an openmaptiles import and generating vector tiles
```
ERROR:  relation "spatial_ref_sys" does not exist at character 23
QUERY:  SELECT proj4text FROM spatial_ref_sys WHERE srid = 3857 LIMIT 1
CONTEXT:  automatic analyze of table "gis.public.osm_waterway_linestring_gen2"
ERROR:  relation "spatial_ref_sys" does not exist at character 23
QUERY:  SELECT proj4text FROM spatial_ref_sys WHERE srid = 3857 LIMIT 1
CONTEXT:  automatic analyze of table "gis.public.osm_city_point"
ERROR:  relation "spatial_ref_sys" does not exist at character 23
QUERY:  SELECT proj4text FROM spatial_ref_sys WHERE srid = 3857 LIMIT 1
CONTEXT:  automatic analyze of table "gis.public.osm_poi_point"
...
```

After investigation, it seems this is due to [a change introduced in PostgreSQL 9.6.8](https://www.postgresql.org/docs/9.6/release-9-6-8.html), where the tighter "search_path" used by autovacuum workers may result in errors.

And that was fixed in PostGIS 2.4.3 by https://github.com/postgis/postgis/commit/40ac54854a82e4cbf554c9cef6bac5e32f575f21

Hence, the recommendation to use the latest versions for PostGIS 2.4 and GEOS 3.6.