### PR TITLE
Fix crash if multiple files with same attribute have different hashes.

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -184,7 +184,7 @@ class Catalog:
                           f"hashes:")
                     print(f"* {source}, {attr_desc}={attr}, hash={source.hash}")
                     src = sources_by_hash[attr_to_hash[attr]][0]
-                    print(f"* {src}, {attr_desc}={(getattr(src, attr_name))}, "
+                    print(f"* {src}, {attr_desc}={getattr(src, attr_name)}, "
                           f"hash={src.hash}")
                     return None
         return attr_to_hash

--- a/bin/download-osm
+++ b/bin/download-osm
@@ -184,7 +184,7 @@ class Catalog:
                           f"hashes:")
                     print(f"* {source}, {attr_desc}={attr}, hash={source.hash}")
                     src = sources_by_hash[attr_to_hash[attr]][0]
-                    print(f"* {src}, {attr_desc}={(getattr(src, attr))}, "
+                    print(f"* {src}, {attr_desc}={(getattr(src, attr_name))}, "
                           f"hash={src.hash}")
                     return None
         return attr_to_hash


### PR DESCRIPTION
When multiple files with same attribute have different hashes exist,
script trying to call 'getattr' function with one of the arguments 'attr' in string 187.
'attr' - is the 'attr_name' value so it causes script crash.
Fix it using 'attr_name' as argument to 'getattr' function call.