### PR TITLE
Add build-all-dockers makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,17 @@ prepare:
 build-docker:
 	docker build --file Dockerfile --tag $(DOCKER_IMAGE) .
 
+.PHONY: build-all-dockers
+build-all-dockers: build-docker
+	@for dir in docker/postgis $(wildcard docker/generate-*) $(wildcard docker/import-*); do \
+	( \
+		cd $$dir && \
+		echo "\n\n*****************************************************" && \
+		echo "Building $${dir#docker/}:$(VERSION) in $$dir..." && \
+		docker build --file Dockerfile --tag $${dir#docker/}:$(VERSION) . \
+	) ;\
+	done
+
 .PHONY: run-python-tests
 run-python-tests: build-docker
 	@echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"


### PR DESCRIPTION
a target that builds all available `docker/*` directories
tagging them with the current version.