### PR TITLE
Revert to dataclasses-json==0.3.6 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ aiohttp==3.6.2
 ascii_graph==1.5.1
 asyncpg==0.20.1
 beautifulsoup4==4.8.2
-dataclasses-json==0.3.8
+# DO NOT UPGRADE: version 0.3.7 introduced backward incompatible changes
+dataclasses-json==0.3.6
 deprecated==1.2.7
 docopt-ng==0.7.2
 graphviz==0.13.2


### PR DESCRIPTION
The dataclasses-json 0.3.7 introduced a backward incompatible
issue with instantiating data classes with parameters.

Reverting to 0.3.6 for now