### PR TITLE
Imposm tags

### DIFF
--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -25,13 +25,9 @@ def create_imposm3_mapping(tileset_filename):
     include_tags.append('name')
     include_tags.append('wikidata')
     include_tags.append('wikipedia')
-    include_tags = set(include_tags)
 
     generalized_tables = {}
     tables = {}
-    tags = {
-        'include': include_tags
-    }
 
     for layer in tileset.layers:
         for mapping in layer.imposm_mappings:
@@ -39,12 +35,14 @@ def create_imposm3_mapping(tileset_filename):
                 if 'tolerance' in definition:
                     try:  # Test if numeric
                         float(definition['tolerance'])
-                    except:
+                    except ValueError:
                         if re.match(r"^ZRES\d{1,2}$", definition['tolerance']):
                             zoom = definition['tolerance'][4:6]
-                            definition['tolerance'] = zres(float(pixel_scale), float(zoom))  # Convert to distance
+                            definition['tolerance'] = zres(float(pixel_scale), float(
+                                zoom))  # Convert to distance
                         else:
-                            raise SyntaxError('Unrecognized tolerance ' + str(definition['tolerance']))
+                            raise SyntaxError('Unrecognized tolerance ' + str(
+                                definition['tolerance']))
                 if 'sql_filter' in definition:
                     definition['sql_filter'] = re.sub(
                         r"ZRES\d{1,2}",
@@ -55,15 +53,20 @@ def create_imposm3_mapping(tileset_filename):
                 # Remove all OpenMapTiles custom keys to avoid confusing Imposm
                 definition.pop('_resolve_wikidata', None)
                 tables[table_name] = definition
-            for tag_name, definition in mapping.get('tags', {}).items():
-                if tag_name == 'include':
-                    tags[tag_name] |= set(definition)
-                tags[tag_name] = definition
-
-    include_tags = sorted(list(include_tags))
+            for tags_key, tags_val in mapping.get('tags', {}).items():
+                if tags_key == 'include':
+                    if not isinstance(tags_val, list) or any(
+                        (v for v in tags_val if not v or not isinstance(v, str))
+                    ):
+                        raise ValueError(f"Tileset {tileset.name} mapping's "
+                                         f"tags/include must be a list of strings")
+                    include_tags += tags_val
+                else:
+                    raise ValueError(f"Tileset {tileset.name} mapping tags "
+                                     f"uses an unsupported key '{tags_key}'")
 
     return {
-        'tags': tags,
+        'tags': dict(include=list(sorted(set(include_tags)))),
         'generalized_tables': generalized_tables,
         'tables': tables,
     }

--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -4,12 +4,12 @@ from .tileset import Tileset
 
 def zres(pixel_scale, zoom):
     # See https://github.com/openmaptiles/postgis-vt-util/blob/master/src/ZRes.sql
-    return 40075016.6855785 / ((1.0 * pixel_scale) * 2 ** zoom)
+    return 40075016.6855785 / ((1.0 * float(pixel_scale)) * 2 ** float(zoom))
 
 
 def call_zres(pixel_scale, match):
     # See https://github.com/openmaptiles/postgis-vt-util/blob/master/src/ZRes.sql
-    return str(zres(float(pixel_scale), float(match.group(0)[4:6])))
+    return str(zres(pixel_scale, match.group(0)[4:6]))
 
 
 def create_imposm3_mapping(tileset_filename):
@@ -38,11 +38,11 @@ def create_imposm3_mapping(tileset_filename):
                     except ValueError:
                         if re.match(r"^ZRES\d{1,2}$", definition['tolerance']):
                             zoom = definition['tolerance'][4:6]
-                            definition['tolerance'] = zres(float(pixel_scale), float(
-                                zoom))  # Convert to distance
+                            # Convert to distance
+                            definition['tolerance'] = zres(pixel_scale, zoom)
                         else:
-                            raise SyntaxError('Unrecognized tolerance ' + str(
-                                definition['tolerance']))
+                            raise SyntaxError(
+                                f"Unrecognized tolerance '{definition['tolerance']}'")
                 if 'sql_filter' in definition:
                     definition['sql_filter'] = re.sub(
                         r"ZRES\d{1,2}",

--- a/openmaptiles/imposm.py
+++ b/openmaptiles/imposm.py
@@ -25,6 +25,7 @@ def create_imposm3_mapping(tileset_filename):
     include_tags.append('name')
     include_tags.append('wikidata')
     include_tags.append('wikipedia')
+    include_tags = set(include_tags)
 
     generalized_tables = {}
     tables = {}
@@ -55,7 +56,11 @@ def create_imposm3_mapping(tileset_filename):
                 definition.pop('_resolve_wikidata', None)
                 tables[table_name] = definition
             for tag_name, definition in mapping.get('tags', {}).items():
+                if tag_name == 'include':
+                    tags[tag_name] |= set(definition)
                 tags[tag_name] = definition
+
+    include_tags = sorted(list(include_tags))
 
     return {
         'tags': tags,

--- a/tests/expected/imposm3.yaml
+++ b/tests/expected/imposm3.yaml
@@ -22,12 +22,12 @@ tables:
 tags:
   include:
   - access
-  - name:en
-  - name:de
-  - name:cs
   - int_name
   - loc_name
   - name
+  - name:cs
+  - name:de
+  - name:en
   - wikidata
   - wikipedia
 

--- a/tests/expected/imposm3.yaml
+++ b/tests/expected/imposm3.yaml
@@ -21,6 +21,7 @@ tables:
         - __any__
 tags:
   include:
+  - access
   - name:en
   - name:de
   - name:cs

--- a/tests/testlayers/housenumber/mapping.yaml
+++ b/tests/testlayers/housenumber/mapping.yaml
@@ -1,5 +1,6 @@
 tags:
-  include: [access]
+  include:
+    - access
 
 tables:
 

--- a/tests/testlayers/housenumber/mapping.yaml
+++ b/tests/testlayers/housenumber/mapping.yaml
@@ -1,3 +1,5 @@
+tags:
+  include: [access]
 
 tables:
 


### PR DESCRIPTION
Fix imposm tags handling, allowing different layers to include additional tags (rather than overriding it, thus the last layer wins).

Fixes #179

Side cleanup - slightly better syntax for zres parsing & error handling.