### PR TITLE
osm-download make-dc fix, clean up

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -63,7 +63,6 @@ where the 3rd parameter is the name of the PDF file. Will run make-dc command.
 """
 
 import asyncio
-import html
 import json
 import os
 import re
@@ -375,7 +374,8 @@ async def save_state_file(session, state_url, state_file):
 
 
 async def prepare_area_download(args, session):
-    area_id = args['<id>'].strip() if args['<id>'] else False
+    area_id = (args['<id>'] or args['--id'] or "").strip()
+    area_id = area_id if area_id else None
     if args.url:
         url = args['<url>']
     elif args.bbbike:
@@ -421,7 +421,7 @@ async def prepare_area_download(args, session):
     await asyncio.wait([src.load_hash(session, args.verbose),
                         src.load_metadata(session, args.verbose)])
     print(f"Downloading {src.url} (size={src.size_str()}, md5={src.hash})", flush=True)
-    return [src.url], src.hash
+    return [src.url], src.hash, area_id
 
 
 def make_docker_compose_file(pbf_file: Path, dc_file: Path,
@@ -463,24 +463,21 @@ def make_docker_compose_file(pbf_file: Path, dc_file: Path,
 
 
 def normalize_make_dc(area, min_zoom, max_zoom):
-    area = os.environ.get("OSM_AREA_NAME", "Unknown") if area is None else area
+    area = os.environ.get("OSM_AREA_NAME", "Unknown") if not area else area
     min_zoom = int(os.environ.get("MIN_ZOOM", 0) if min_zoom is None else min_zoom)
     max_zoom = int(os.environ.get("MAX_ZOOM", 7) if max_zoom is None else max_zoom)
     return area, min_zoom, max_zoom
 
 
 async def main_async(args):
-    dry_run = args['--dry-run']
-    aria2c_args = args.args
-    urls, md5 = None, None
-    exit_code = 0
+    if args["make-dc"]:
+        return make_docker_compose_file(
+            Path(args["<pbf-file>"]), Path(args["--make-dc"]),
+            args['--minzoom'], args['--maxzoom'], args["--id"])
 
+    urls, md5 = None, None
     async with aiohttp.ClientSession(headers={'User-Agent': USER_AGENT}) as session:
-        if args.planet:
-            use_primary = args['--include-primary']
-            urls, md5 = await Catalog().init(session, args.verbose, use_primary,
-                                             args['--force-latest'])
-        elif args.list:
+        if args.list:
             if args.service != "geofabrik":
                 raise SystemExit('List only supports geofabrik service for now')
             catalog = await get_geofabrik_list(session, args['--force-latest'],
@@ -488,22 +485,20 @@ async def main_async(args):
             info = [dict(id=v["full_id"], name=v["full_name"]) for v in
                     catalog.values()]
             print(tabulate(info, headers="keys") + '\n')
-        elif args["make-dc"]:
-            exit_code = make_docker_compose_file(
-                Path(args["<pbf-file>"]), Path(args["--make-dc"]),
-                args['--minzoom'], args['--maxzoom'], args['--id'])
+        elif args.planet:
+            use_primary = args['--include-primary']
+            urls, md5 = await Catalog().init(session, args.verbose, use_primary,
+                                             args['--force-latest'])
+            area_id = "planet"
         else:
-            urls, md5 = await prepare_area_download(args, session)
+            urls, md5, area_id = await prepare_area_download(args, session)
 
     if urls:
-        exit_code = await run_aria2c(aria2c_args, dry_run, md5, urls, args)
-        if dry_run and args['--make-dc']:
-            print("docker-compose file generation was skipped in the dry-run mode")
-
-    return exit_code
+        return await run_aria2c(args.args, args['--dry-run'], md5, urls, args, area_id)
+    return 0
 
 
-async def run_aria2c(aria2c_args, dry_run, md5, urls, args):
+async def run_aria2c(aria2c_args, dry_run, md5, urls, args, area_id):
     params = ['aria2c']
     if md5:
         params.append(f'--checksum=md5={md5}')
@@ -525,11 +520,11 @@ async def run_aria2c(aria2c_args, dry_run, md5, urls, args):
             if any((v for v in aria2c_args if v.startswith(flag))):
                 raise ValueError("Unable to use --make-dc together with "
                                  f"the {flag} aria2c parameter")
-        area, min_zoom, max_zoom = normalize_make_dc(args['--id'], args['--minzoom'],
-                                                     args['--maxzoom'])
+        area_id, min_zoom, max_zoom = normalize_make_dc(
+            area_id, args['--minzoom'], args['--maxzoom'])
         extra_env = {
             "DOWNLOAD_OSM_DC_FILE": str(Path(args['--make-dc'])),
-            "OSM_AREA_NAME": str(area),
+            "OSM_AREA_NAME": str(area_id),
             "MIN_ZOOM": str(min_zoom),
             "MAX_ZOOM": str(max_zoom)
         }
@@ -580,6 +575,8 @@ async def run_aria2c(aria2c_args, dry_run, md5, urls, args):
         return ret
     else:
         print("Data is not downloaded because of the --dry-run parameter")
+        if args['--make-dc']:
+            print("docker-compose file generation was skipped")
         return 0
 
 

--- a/tests/cache/geofabrik.json
+++ b/tests/cache/geofabrik.json
@@ -1,0 +1,58 @@
+{
+  "DESCRIPTION": "This is a fake catalog of Geofabrik areas used in testing",
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "monaco-test",
+        "parent": "europe",
+        "iso3166-1:alpha2": [
+          "MC"
+        ],
+        "name": "A test file",
+        "urls": {
+          "pbf": "http://localhost:8555/monaco-20150428.osm.pbf"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id" : "us/michigan",
+        "parent" : "north-america",
+        "iso3166-2" : [ "US-MI" ],
+        "name" : "Michigan",
+        "urls" : {
+          "pbf" : "https://download.geofabrik.de/north-america/us/michigan-latest.osm.pbf",
+          "bz2" : "https://download.geofabrik.de/north-america/us/michigan-latest.osm.bz2",
+          "shp" : "https://download.geofabrik.de/north-america/us/michigan-latest-free.shp.zip",
+          "pbf-internal" : "https://osm-internal.download.geofabrik.de/north-america/us/michigan-latest-internal.osm.pbf",
+          "history" : "https://osm-internal.download.geofabrik.de/north-america/us/michigan-internal.osh.pbf",
+          "taginfo" : "https://taginfo.geofabrik.de/north-america/us/michigan/",
+          "updates" : "https://download.geofabrik.de/north-america/us/michigan-updates"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id" : "europe",
+        "name" : "Europe",
+        "urls" : {
+          "pbf" : "https://download.geofabrik.de/europe-latest.osm.pbf"
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id" : "north-america",
+        "name" : "North America",
+        "urls" : {
+          "pbf" : "https://download.geofabrik.de/north-america-latest.osm.pbf"
+        }
+      }
+    }
+  ]
+}

--- a/tests/expected/monaco-dc2.yml
+++ b/tests/expected/monaco-dc2.yml
@@ -4,6 +4,6 @@ services:
     environment:
       BBOX: 7.3830115,43.5163330,7.5003330,43.7543525
       OSM_MAX_TIMESTAMP: '2015-04-27T19:32:23Z'
-      OSM_AREA_NAME: raw-url
-      MIN_ZOOM: 0
-      MAX_ZOOM: 10
+      OSM_AREA_NAME: monaco-test2
+      MIN_ZOOM: 3
+      MAX_ZOOM: 5

--- a/tests/expected/monaco-dc3.yml
+++ b/tests/expected/monaco-dc3.yml
@@ -4,6 +4,6 @@ services:
     environment:
       BBOX: 7.3830115,43.5163330,7.5003330,43.7543525
       OSM_MAX_TIMESTAMP: '2015-04-27T19:32:23Z'
-      OSM_AREA_NAME: raw-url
-      MIN_ZOOM: 0
-      MAX_ZOOM: 10
+      OSM_AREA_NAME: monaco-test
+      MIN_ZOOM: 5
+      MAX_ZOOM: 6

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -4,8 +4,9 @@ set -o errexit  # -e
 set -o pipefail
 set -o nounset  # -u
 
-TESTLAYERS="tests/testlayers"
-HTTPDIR="tests/http"
+TESTS=tests
+TESTLAYERS="$TESTS/testlayers"
+HTTPDIR="$TESTS/http"
 DEVDOC=${BUILD?}/devdoc
 mkdir -p "${DEVDOC}"
 
@@ -57,4 +58,16 @@ python -m http.server 8555 -d "$HTTPDIR" &
 trap "kill $!" EXIT
 
 download-osm url http://localhost:8555/monaco-20150428.osm.pbf \
-  --verbose --make-dc "$BUILD/monaco-dc.yml" --id monaco-test --minzoom 0 --maxzoom 10 -- --dir /tmp
+  --verbose --make-dc "$BUILD/monaco-dc.yml" --id raw-url --minzoom 0 --maxzoom 10 -- --dir /tmp
+
+# Test downloader support for env vars
+export OSM_AREA_NAME=monaco-test2
+export MIN_ZOOM=3
+export MAX_ZOOM=5
+download-osm url http://localhost:8555/monaco-20150428.osm.pbf \
+  --verbose --make-dc "$BUILD/monaco-dc2.yml" -- --dir /tmp
+unset OSM_AREA_NAME MIN_ZOOM MAX_ZOOM
+
+# Using a fake cache/geofabrik.json so that downloader wouldn't need to download the real one from Geofabrik site
+download-osm geofabrik monaco-test \
+  --verbose --make-dc "$BUILD/monaco-dc3.yml" --minzoom 5 --maxzoom 6 -- --dir /tmp


### PR DESCRIPTION
* fix passing of the area id to the --make-dc when downloading from Geofabrik
* handle all docker dirs in the build-all-dockers target
* add an extra test for osm-downloader