### PR TITLE
New postgis-preloaded image - db with base data

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -58,6 +58,16 @@ Each subdir here creates a docker image that either generates some data, or is b
 [![](https://img.shields.io/docker/stars/openmaptiles/postgis?label=stars)](https://hub.docker.com/r/openmaptiles/postgis)
 <br><small>Migrated from [postgis](https://github.com/openmaptiles/postgis) repo (archived)</small>
 
+## [postgis-preloaded](postgis-preloaded)
+[![](https://img.shields.io/docker/cloud/build/openmaptiles/postgis-preloaded?&logo=OpenStreetMap&label=build)](https://hub.docker.com/r/openmaptiles/postgis-preloaded)
+[![](https://img.shields.io/docker/automated/openmaptiles/postgis-preloaded?label=build)](https://hub.docker.com/r/openmaptiles/postgis-preloaded/builds)
+[![](https://img.shields.io/microbadger/layers/openmaptiles/postgis-preloaded)](https://hub.docker.com/r/openmaptiles/postgis-preloaded)
+[![](https://img.shields.io/microbadger/image-size/openmaptiles/postgis-preloaded?label=size)](https://hub.docker.com/r/openmaptiles/postgis-preloaded)
+[![](https://img.shields.io/docker/pulls/openmaptiles/postgis-preloaded?label=downloads)](https://hub.docker.com/r/openmaptiles/postgis-preloaded)
+[![](https://img.shields.io/docker/stars/openmaptiles/postgis-preloaded?label=stars)](https://hub.docker.com/r/openmaptiles/postgis-preloaded)
+
+A data-preloaded database image used mostly for testing. The image is based on the `postgis` image above, initialized with the `openmaptiles` database (user=openmaptiles, password=openmaptiles), preloaded with water, lakelines, and natural-earth data.
+
 # Deprecated Legacy Tools
 
 These Docker images are no longer maintained or published, and should not be used.

--- a/docker/postgis-preloaded/Dockerfile
+++ b/docker/postgis-preloaded/Dockerfile
@@ -1,0 +1,44 @@
+FROM openmaptiles/import-lakelines as lakelines
+FROM openmaptiles/import-natural-earth as natural-earth
+FROM openmaptiles/import-water as water
+
+FROM openmaptiles/postgis
+
+# There is a relevant discussion in
+# https://github.com/docker-library/postgres/issues/661#issuecomment-573192715
+
+# Override PGDATA to change the default location of the Postgres data directory
+# to another place that has not been created as a volume
+ENV  IMPORT_DIR=/import \
+     POSTGRES_DB=openmaptiles \
+     POSTGRES_USER=openmaptiles \
+     POSTGRES_PASSWORD=openmaptiles \
+     PGDATA=/var/lib/postgresql/data_no_volume
+
+# switch to postgres user for ownership and execution
+USER postgres
+
+COPY --from=lakelines /usr/src/app/import_lakelines.sh /docker-entrypoint-initdb.d/20_import_lakelines.sh
+COPY --from=lakelines $IMPORT_DIR/lake_centerline.geojson $IMPORT_DIR/
+
+ENV NATURAL_EARTH_DB=/import/natural_earth_vector.sqlite
+COPY --from=natural-earth /usr/src/app/import-natural-earth.sh /docker-entrypoint-initdb.d/30_import-natural-earth.sh
+COPY --from=natural-earth $IMPORT_DIR/natural_earth_vector.sqlite $IMPORT_DIR/
+
+ENV IMPORT_DATA_DIR=/import
+COPY --from=water /usr/src/app/import-water.sh /docker-entrypoint-initdb.d/40_import-water.sh
+COPY --from=water $IMPORT_DIR/* $IMPORT_DIR/
+
+COPY custom-entrypoint.sh /usr/local/bin/
+
+# create custom data dir with ownership to postgres user
+RUN mkdir -p "${PGDATA}"
+
+# execute custom entry point to initialize with scripts and build the data dir
+RUN custom-entrypoint.sh postgres || exit 0
+
+ENTRYPOINT [ "custom-entrypoint.sh" ]
+
+# using this CMD works so that docker run ... doesnt require a command override,
+# only downside is it calls SET for this parameter on every psql issued to the container
+CMD [ "-c", "max_locks_per_transaction=512" ]

--- a/docker/postgis-preloaded/LICENSE
+++ b/docker/postgis-preloaded/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2020, Yuri Astrakhan (YuriAstrakhan@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/docker/postgis-preloaded/README.md
+++ b/docker/postgis-preloaded/README.md
@@ -1,0 +1,6 @@
+# Preloaded Postgis Image [![Docker Automated build](https://img.shields.io/docker/automated/openmaptiles/postgis-preloaded.svg?maxAge=2592000)](https://hub.docker.com/r/openmaptiles/postgis-preloaded/)
+
+This is a Docker image that has been pre-loaded with lakelines, natural-earth, and water data.
+This image can be used for quicker testing, but might be less suited for a production environment.
+
+The image contains a PostgreSQL database `openmaptiles`, user=openmaptiles, password=openmaptiles

--- a/docker/postgis-preloaded/custom-entrypoint.sh
+++ b/docker/postgis-preloaded/custom-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+# This code was adapted from a postgres issue
+# https://github.com/docker-library/postgres/issues/661#issuecomment-573192715
+
+source "$(command -v docker-entrypoint.sh)"
+
+docker_setup_env
+docker_create_db_directories
+
+if [[ -z "$DATABASE_ALREADY_EXISTS" ]]; then
+  docker_verify_minimum_env
+  docker_init_database_dir
+  pg_setup_hba_conf
+
+  # only required for '--auth[-local]=md5' on POSTGRES_INITDB_ARGS
+  export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+
+  # Support for the import scripts from other docker containers
+  # Override PGCONN so that ogr2ogr would connect via socket rather than TCP
+  export PGCONN="dbname=$POSTGRES_DB user=$POSTGRES_USER password=$PGPASSWORD"
+
+  docker_temp_server_start "$@" -c max_locks_per_transaction=256
+  docker_setup_db
+  docker_process_init_files /docker-entrypoint-initdb.d/*
+  docker_temp_server_stop
+fi
+
+exec postgres "$@"


### PR DESCRIPTION
This is a Docker image that has been pre-loaded with lakelines, natural-earth, and water data.
This image can be used for quicker testing, but might be less suited for a production environment.

The image contains a PostgreSQL database `openmaptiles`, user=openmaptiles, password=openmaptiles