### PR TITLE
Revert to ogr2ogr 3.0.2

### DIFF
--- a/docker/import-data/Dockerfile
+++ b/docker/import-data/Dockerfile
@@ -27,7 +27,7 @@ RUN DIR=/downloads/lake_centerline \
  && wget --quiet https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
 
 
-FROM osgeo/gdal:alpine-normal-3.0.4
+FROM osgeo/gdal:alpine-normal-3.0.2
 LABEL maintainer="YuriAstrakhan@gmail.com"
 
 ENV IMPORT_DIR=/import


### PR DESCRIPTION
This is due to 3.0.3+ showing an data importing issue.
* https://github.com/OSGeo/gdal/issues/2301