### PR TITLE
mbtiles-tools meta generate & copy commands

### DIFF
--- a/bin/mbtiles-tools
+++ b/bin/mbtiles-tools
@@ -10,20 +10,35 @@ Usage:
   mbtiles-tools meta-all <mbtilesfile>
   mbtiles-tools meta-get <mbtilesfile> <metakey>
   mbtiles-tools meta-set <mbtilesfile> <metakey> [<newvalue>]
+  mbtiles-tools meta-generate <mbtilesfile> <tileset>
+                [--reset] [--auto-minmax]
+                [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+                [--user=<user>] [--password=<password>]
   mbtiles-tools --help
   mbtiles-tools --version
 
+
+  <mbtilesfile>  sqlite3 database file with .mbtiles extension
+  <tileset>      Tileset definition yaml file
+
 Actions:
-  find-dups Get a list of duplicate tile keys at a given zoom levels (optional),
-            limiting by the tile size (optional).
-  impute    Look at the zoom level one less than <zoom>, and find all tiles that match
-            the given keys (md5 hashes as strings or a file). For each found tile,
-            add tiles at the higher zooms with the same content as the found ones.
-            For example, given a key for an empty water tile, one could clone all such
-            water tiles from zoom 13 to zoom 14 by using --zoom=14 --key=<hash>
-  meta-all  validates and prints all values in the metadata table
-  meta-get  Gets a single value from metadata table
-  meta-set  Sets a single value in the metadata table, or deletes it if no value.
+  find-dups      Get a list of duplicate tile keys at a given zoom levels (optional),
+                 limiting by the tile size (optional).
+  impute         Look at the zoom level one less than <zoom>, and find all tiles that match
+                 the given keys (md5 hashes as strings or a file). For each found tile,
+                 add tiles at the higher zooms with the same content as the found ones.
+                 For example, given a key for an empty water tile, one could clone all such
+                 water tiles from zoom 13 to zoom 14 by using --zoom=14 --key=<hash>
+  meta-all       validates and prints all values in the metadata table
+  meta-get       Gets a single value from metadata table
+  meta-set       Sets a single value in the metadata table, or deletes it if no value.
+  meta-generate  Initialize metadata table with the values from Postgres and tileset,
+                 optionally overriding the bounding box and other params with env vars:
+                    BBOX, CENTER_ZOOM -- center zoom will only be used if BBOX is set
+                    MIN_ZOOM, MAX_ZOOM -- will override tileset except if --auto-minmax is set
+                    METADATA_ATTRIBUTION, METADATA_DESCRIPTION, METADATA_NAME, METADATA_VERSION
+                 Supports env variables METADATA_* for overwriting metadata values.
+                 Requires a database connection.
 
 Options:
   -z --zoom=<zoom>      Process a single zoom. If set, ignores min/max.
@@ -33,17 +48,29 @@ Options:
   -f --keyfile=<file>   A file with tile Keys, one per line.
   -o --output=<file>    Write a list of tiles to this file. Use '-' for stdout.
   -v --verbose          Print additional debugging information.
-  --maxsize=<size>      Ensure tile size is no bigger than <size>.
-  --force               Force action, see action description.
+  --reset               For meta-generate, when set will clear all existing metadata first.
+  -a --auto-minmax      For meta-generate, query data tables for available min/max zoom.
   --help                Show this screen.
   --version             Show version.
+
+PostgreSQL Options:
+  -h --pghost=<host>    Postgres hostname. By default uses PGHOST env or "localhost" if not set.
+  -P --pgport=<port>    Postgres port. By default uses PGPORT env or "5432" if not set.
+  -d --dbname=<db>      Postgres db name. By default uses PGDATABASE env or "openmaptiles" if not set.
+  -U --user=<user>      Postgres user. By default uses PGUSER env or "openmaptiles" if not set.
+  --password=<password> Postgres password. By default uses PGPASSWORD env or "openmaptiles" if not set.
+
+These legacy environment variables should not be used, but they are still supported:
+  POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
 """
+import asyncio
 from pathlib import Path
 
 from docopt import docopt, DocoptExit
-import openmaptiles
 
+import openmaptiles
 from openmaptiles.mbtile_tools import Imputer, KeyFinder, Metadata
+from openmaptiles.pgutils import parse_pg_args
 
 
 def main():
@@ -59,6 +86,11 @@ def main():
     elif args['meta-set']:
         Metadata(args['<mbtilesfile>']).set_value(
             args['<metakey>'], args['<newvalue>'])
+    elif args['meta-generate']:
+        pghost, pgport, dbname, user, password = parse_pg_args(args)
+        asyncio.run(Metadata(args['<mbtilesfile>']).generate(
+            args['<tileset>'], reset=args['--reset'], auto_minmax=args['--auto-minmax'],
+            pghost=pghost, pgport=pgport, dbname=dbname, user=user, password=password))
     else:
         raise DocoptExit('Invalid command')
 
@@ -84,7 +116,7 @@ def impute(args):
     elif args['--key']:
         keys = args['--key']
     else:
-        keys = KeyFinder(file, show_size=False, zoom=zoom-1).run()
+        keys = KeyFinder(file, show_size=False, zoom=zoom - 1).run()
     Imputer(file, keys, zoom, outfile, verbose).run()
 
 

--- a/bin/mbtiles-tools
+++ b/bin/mbtiles-tools
@@ -3,22 +3,24 @@
 A toolbox to manage the mbtiles file.
 
 Usage:
-  mbtiles-tools find-dups <mbtilesfile> [--output=<file>] [--verbose]
-  mbtiles-tools impute <mbtilesfile> --zoom=<zoom>
+  mbtiles-tools find-dups <mbtiles-file> [--output=<file>] [--verbose]
+  mbtiles-tools impute <mbtiles-file> --zoom=<zoom>
                 [--key=<hash>... | --keyfile=<file>] [--output=<file>]
                 [--verbose]
-  mbtiles-tools meta-all <mbtilesfile>
-  mbtiles-tools meta-get <mbtilesfile> <metakey>
-  mbtiles-tools meta-set <mbtilesfile> <metakey> [<newvalue>]
-  mbtiles-tools meta-generate <mbtilesfile> <tileset>
+  mbtiles-tools meta-all <mbtiles-file>
+  mbtiles-tools meta-get <mbtiles-file> <metakey>
+  mbtiles-tools meta-set <mbtiles-file> <metakey> [<newvalue>]
+  mbtiles-tools meta-generate <mbtiles-file> <tileset>
                 [--reset] [--auto-minmax]
                 [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
                 [--user=<user>] [--password=<password>]
+  mbtiles-tools meta-copy <mbtiles-file> <target-mbtiles-file>
+                [--reset] [--auto-minmax]
   mbtiles-tools --help
   mbtiles-tools --version
 
 
-  <mbtilesfile>  sqlite3 database file with .mbtiles extension
+  <mbtiles-file>  sqlite3 database file with .mbtiles extension
   <tileset>      Tileset definition yaml file
 
 Actions:
@@ -37,8 +39,11 @@ Actions:
                     BBOX, CENTER_ZOOM -- center zoom will only be used if BBOX is set
                     MIN_ZOOM, MAX_ZOOM -- will override tileset except if --auto-minmax is set
                     METADATA_ATTRIBUTION, METADATA_DESCRIPTION, METADATA_NAME, METADATA_VERSION
-                 Supports env variables METADATA_* for overwriting metadata values.
                  Requires a database connection.
+  meta-copy      Copy all metadata from one mbtile file to another.
+                 While copying, values could also be updated by the same env vars as
+                 meta-generate, and can also be modified with --auto-minmax.
+
 
 Options:
   -z --zoom=<zoom>      Process a single zoom. If set, ignores min/max.
@@ -48,8 +53,8 @@ Options:
   -f --keyfile=<file>   A file with tile Keys, one per line.
   -o --output=<file>    Write a list of tiles to this file. Use '-' for stdout.
   -v --verbose          Print additional debugging information.
-  --reset               For meta-generate, when set will clear all existing metadata first.
-  -a --auto-minmax      For meta-generate, query data tables for available min/max zoom.
+  --reset               For meta-generate and meta-copy, clear all existing metadata first.
+  -a --auto-minmax      For meta-generate and meta-copy, query data tables for available min/max zoom.
   --help                Show this screen.
   --version             Show version.
 
@@ -80,31 +85,36 @@ def main():
     elif args['impute']:
         impute(args)
     elif args['meta-all']:
-        Metadata(args['<mbtilesfile>']).print_all()
+        Metadata(args['<mbtiles-file>']).print_all()
     elif args['meta-get']:
-        Metadata(args['<mbtilesfile>']).get_value(args['<metakey>'])
+        Metadata(args['<mbtiles-file>']).get_value(args['<metakey>'])
     elif args['meta-set']:
-        Metadata(args['<mbtilesfile>']).set_value(
+        Metadata(args['<mbtiles-file>']).set_value(
             args['<metakey>'], args['<newvalue>'])
     elif args['meta-generate']:
         pghost, pgport, dbname, user, password = parse_pg_args(args)
-        asyncio.run(Metadata(args['<mbtilesfile>']).generate(
+        asyncio.run(Metadata(args['<mbtiles-file>']).generate(
             args['<tileset>'], reset=args['--reset'], auto_minmax=args['--auto-minmax'],
             pghost=pghost, pgport=pgport, dbname=dbname, user=user, password=password))
+    elif args['meta-copy']:
+        Metadata(args['<mbtiles-file>']).copy(
+            args['<target-mbtiles-file>'],
+            reset=args['--reset'],
+            auto_minmax=args['--auto-minmax'])
     else:
         raise DocoptExit('Invalid command')
 
 
 def find_dups(args):
     KeyFinder(
-        mbtiles=args['<mbtilesfile>'],
+        mbtiles=args['<mbtiles-file>'],
         outfile=args['--output'] or '-',
         verbose=args['--verbose'] or (args['--output'] and args['--output'] != '-'),
     ).run()
 
 
 def impute(args):
-    file = args['<mbtilesfile>']
+    file = args['<mbtiles-file>']
     verbose = args['--verbose']
     zoom = int(args['--zoom'])
     if zoom <= 0:

--- a/openmaptiles/mbtile_tools.py
+++ b/openmaptiles/mbtile_tools.py
@@ -1,10 +1,16 @@
 import json
+import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 
+import asyncpg
+
+from openmaptiles.pgutils import get_postgis_version, get_vector_layers
 from openmaptiles.sqlite_utils import query
-from openmaptiles.utils import print_err
+from openmaptiles.sqltomvt import MvtGenerator
+from openmaptiles.tileset import Tileset
+from openmaptiles.utils import print_err, Bbox
 
 
 class KeyFinder:
@@ -178,36 +184,37 @@ class Imputer:
             yield with_key, without_key
 
 
-class Metadata():
+def validate(name, value):
+    if name == 'mtime':
+        try:
+            val = datetime.fromtimestamp(int(value) / 1000.0)
+            return f'{value} ({val.isoformat()})', True
+        except ValueError:
+            return f'{value} (invalid)', False
+    elif name in ('filesize', 'maskLevel', 'minzoom', 'maxzoom'):
+        try:
+            return f'{int(value):,}', True
+        except ValueError:
+            return f'{value} (invalid)', False
+    elif name == 'json':
+        try:
+            json.loads(value)
+            return f'(ok)\n{value}', True
+        except ValueError:
+            return f'(invalid)\n{value}', False
+    return value, True
+
+
+class Metadata:
     def __init__(self, mbtiles) -> None:
         self.mbtiles = mbtiles
-
-    def validate(self, name, value):
-        if name == 'mtime':
-            try:
-                val = datetime.fromtimestamp(int(value) / 1000.0)
-                return f'{value} ({val.isoformat()})', True
-            except ValueError:
-                return f'{value} (invalid)', False
-        elif name in ('filesize', 'maskLevel', 'minzoom', 'maxzoom'):
-            try:
-                return f'{int(value):,}', True
-            except ValueError:
-                return f'{value} (invalid)', False
-        elif name == 'json':
-            try:
-                json.loads(value)
-                return f'(ok)\n{value}', True
-            except ValueError:
-                return f'(invalid)\n{value}', False
-        return value, True
 
     def print_all(self):
         with sqlite3.connect(self.mbtiles) as conn:
             data = list(query(conn, "SELECT name, value FROM metadata", []))
         width = max((len(v[0]) for v in data))
         for name, value in sorted(data, key=lambda v: v[0] if v[0] != 'json' else 'zz'):
-            print(f"{name:{width}} {self.validate(name, value)[0]}")
+            print(f"{name:{width}} {validate(name, value)[0]}")
 
     def get_value(self, name):
         with sqlite3.connect(self.mbtiles) as conn:
@@ -220,7 +227,7 @@ class Metadata():
             print(row[0])
 
     def set_value(self, name, value):
-        _, is_valid = self.validate(name, value)
+        _, is_valid = validate(name, value)
         if not is_valid:
             raise ValueError(f"Invalid {name}={value}")
         with sqlite3.connect(self.mbtiles) as conn:
@@ -231,3 +238,67 @@ class Metadata():
                 cursor.execute(
                     "INSERT OR REPLACE INTO  metadata(name, value) VALUES (?, ?);",
                     [name, value])
+
+    async def generate(self, tileset, reset, auto_minmax,
+                       pghost, pgport, dbname, user, password):
+        ts = Tileset.parse(tileset)
+        async with asyncpg.create_pool(
+            database=dbname, host=pghost, port=pgport, user=user,
+            password=password, min_size=1, max_size=1,
+        ) as pool:
+            async with pool.acquire() as conn:
+                mvt = MvtGenerator(
+                    ts,
+                    postgis_ver=await get_postgis_version(conn),
+                    zoom='$1', x='$2', y='$3',
+                )
+                json_data = dict(vector_layers=await get_vector_layers(conn, mvt))
+
+        # Convert tileset to the metadata object according to mbtiles 1.3 spec
+        # https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#content
+        metadata = dict(
+            # MUST
+            name=os.environ.get('METADATA_NAME', ts.name),
+            format="pbf",
+            json=json.dumps(json_data, ensure_ascii=False, separators=(',', ':')),
+            # SHOULD
+            bounds=",".join((str(v) for v in ts.bounds)),
+            center=",".join((str(v) for v in ts.center)),
+            minzoom=os.environ.get('MIN_ZOOM', str(ts.minzoom)),
+            maxzoom=os.environ.get('MAX_ZOOM', str(ts.maxzoom)),
+            # MAY
+            attribution=os.environ.get('METADATA_ATTRIBUTION', ts.attribution),
+            description=os.environ.get('METADATA_DESCRIPTION', ts.description),
+            version=os.environ.get('METADATA_VERSION', ts.version),
+            # EXTRAS
+            filesize=os.path.getsize(self.mbtiles),
+        )
+
+        bbox_str = os.environ.get('BBOX')
+        if bbox_str:
+            bbox = Bbox(bbox=bbox_str,
+                        center_zoom=os.environ.get('CENTER_ZOOM', ts.center[2]))
+            metadata["bounds"] = bbox.bounds_str()
+            metadata["center"] = bbox.center_str()
+
+        with sqlite3.connect(self.mbtiles) as conn:
+            cursor = conn.cursor()
+            if auto_minmax:
+                cursor.execute("SELECT MIN(zoom_level), MAX(zoom_level) FROM map")
+                min_z, max_z = cursor.fetchone()
+                if min_z is None:
+                    raise ValueError("Unable to get min/max zoom - tile data is empty")
+                metadata["minzoom"] = min_z
+                metadata["maxzoom"] = max_z
+
+            if reset:
+                cursor.execute("DELETE FROM metadata;")
+            for name, value in metadata.items():
+                _, is_valid = validate(name, value)
+                if not is_valid:
+                    raise ValueError(f"Invalid {name}={value}")
+                cursor.execute(
+                    "INSERT OR REPLACE INTO  metadata(name, value) VALUES (?, ?);",
+                    [name, value])
+        print("The metadata now contains these values:")
+        self.print_all()

--- a/openmaptiles/postserve.py
+++ b/openmaptiles/postserve.py
@@ -12,7 +12,8 @@ from tornado.log import access_log
 # noinspection PyUnresolvedReferences
 from tornado.web import Application, RequestHandler
 
-from openmaptiles.pgutils import show_settings, get_postgis_version, PgWarnings
+from openmaptiles.pgutils import show_settings, get_postgis_version, PgWarnings, \
+    get_vector_layers
 from openmaptiles.sqltomvt import MvtGenerator
 from openmaptiles.tileset import Tileset
 
@@ -131,7 +132,8 @@ class GetMetadata(RequestHandledWithCors):
 
 class Postserve:
     pool: Pool
-    mvt: MvtGenerator
+    metadata: Dict[str, Any]
+    generated_query: str
 
     def __init__(self, url, port, pghost, pgport, dbname, user, password,
                  layers, tileset_path, sql_file, key_column, disable_feature_ids,
@@ -155,28 +157,84 @@ class Postserve:
 
         self.tileset = Tileset.parse(self.tileset_path)
 
-        self.metadata: Dict[str, Any] = dict(
-            format="pbf",
-            name=self.tileset.name,
-            id=self.tileset.id,
-            bounds=self.tileset.bounds,
-            center=self.tileset.center,
-            maxzoom=self.tileset.maxzoom,
-            minzoom=self.tileset.minzoom,
-            version=self.tileset.version,
-            attribution=self.tileset.attribution,
-            description=self.tileset.description,
-            pixel_scale=self.tileset.pixel_scale,
-            tilejson="2.0.0",
-            tiles=[f"{self.url}" + "/tiles/{z}/{x}/{y}.pbf"],
-            vector_layers=[],
-        )
+    def create_metadata(self,
+                        urls: List[str],
+                        vector_layers: List[dict],
+                        ) -> Dict[str, Any]:
+        """Convert tileset to the tilejson spec
+           https://github.com/mapbox/tilejson-spec/tree/master/2.2.0#2-file-format
+           A few optional parameters were removed as irrelevant
+        """
+        return {
+            # REQUIRED. A semver.org style version number. Describes the version of
+            # the TileJSON spec that is implemented by this JSON object.
+            "tilejson": "2.2.0",
+
+            # OPTIONAL. Default: null. A name describing the tileset. The name can
+            # contain any legal character. Implementations SHOULD NOT interpret the
+            # name as HTML.
+            "name": self.tileset.name,
+
+            # OPTIONAL. Default: null. A text description of the tileset. The
+            # description can contain any legal character. Implementations SHOULD NOT
+            # interpret the description as HTML.
+            "description": self.tileset.description,
+
+            # OPTIONAL. Default: "1.0.0". A semver.org style version number. When
+            # changes across tiles are introduced, the minor version MUST change.
+            # This may lead to cut off labels. Therefore, implementors can decide to
+            # clean their cache when the minor version changes. Changes to the patch
+            # level MUST only have changes to tiles that are contained within one tile.
+            # When tiles change significantly, the major version MUST be increased.
+            # Implementations MUST NOT use tiles with different major versions.
+            "version": self.tileset.version,
+
+            # OPTIONAL. Default: null. Contains an attribution to be displayed
+            # when the map is shown to a user. Implementations MAY decide to treat this
+            # as HTML or literal text. For security reasons, make absolutely sure that
+            # this field can't be abused as a vector for XSS or beacon tracking.
+            "attribution": self.tileset.attribution,
+
+            # REQUIRED. An array of tile endpoints. {z}, {x} and {y}, if present,
+            # are replaced with the corresponding integers. If multiple endpoints are specified, clients
+            # may use any combination of endpoints. All endpoints MUST return the same
+            # content for the same URL. The array MUST contain at least one endpoint.
+            "tiles": urls,
+
+            # OPTIONAL. Default: 0. >= 0, <= 30.
+            # An integer specifying the minimum zoom level.
+            "minzoom": self.tileset.minzoom,
+
+            # OPTIONAL. Default: 30. >= 0, <= 30.
+            # An integer specifying the maximum zoom level. MUST be >= minzoom.
+            "maxzoom": self.tileset.maxzoom,
+
+            # OPTIONAL. Default: [-180, -90, 180, 90].
+            # The maximum extent of available map tiles. Bounds MUST define an area
+            # covered by all zoom levels. The bounds are represented in WGS:84
+            # latitude and longitude values, in the order left, bottom, right, top.
+            # Values may be integers or floating point numbers.
+            "bounds": self.tileset.bounds,
+
+            # OPTIONAL. Default: null.
+            # The first value is the longitude, the second is latitude (both in
+            # WGS:84 values), the third value is the zoom level as an integer.
+            # Longitude and latitude MUST be within the specified bounds.
+            # The zoom level MUST be between minzoom and maxzoom.
+            # Implementations can use this value to set the default location. If the
+            # value is null, implementations may use their own algorithm for
+            # determining a default location.
+            "center": self.tileset.center,
+
+            # This is an undocumented extension to the 2.2 spec that is often used:
+            # https://github.com/mapbox/tilejson-spec/issues/14
+            "vector_layers": vector_layers,
+        }
 
     async def init_connection(self):
-
         async with self.pool.acquire() as conn:
             await show_settings(conn)
-            self.mvt = MvtGenerator(
+            mvt = MvtGenerator(
                 self.tileset,
                 postgis_ver=await get_postgis_version(conn),
                 zoom='$1', x='$2', y='$3',
@@ -187,26 +245,10 @@ class Postserve:
                 test_geometry=self.test_geometry,
                 exclude_layers=self.exclude_layers,
             )
-            pg_types = await get_sql_types(conn)
-            for layer_id, layer in self.mvt.get_layers():
-                fields = await self.mvt.validate_layer_fields(conn, layer_id, layer)
-                unknown = {
-                    name: oid
-                    for name, oid in fields.items() if oid not in pg_types
-                }
-                if unknown:
-                    print(f"Ignoring fields with unknown SQL types (OIDs): "
-                          f"[{', '.join([f'{n} ({o})' for n, o in unknown.items()])}]")
-
-                self.metadata["vector_layers"].append(dict(
-                    id=layer.id,
-                    fields={name: pg_types[type_oid]
-                            for name, type_oid in fields.items()
-                            if type_oid in pg_types},
-                    maxzoom=self.metadata["maxzoom"],
-                    minzoom=self.metadata["minzoom"],
-                    description=layer.description,
-                ))
+            self.generated_query = mvt.generate_sql()
+            self.metadata = self.create_metadata(
+                [self.url + "/tiles/{z}/{x}/{y}.pbf"],
+                await get_vector_layers(conn, mvt))
 
     def serve(self):
         access_log.setLevel(logging.INFO if self.verbose else logging.ERROR)
@@ -225,7 +267,7 @@ class Postserve:
                 query = stream.read()
             print(f'Loaded {self.sql_file}')
         else:
-            query = self.mvt.generate_sql()
+            query = self.generated_query
 
         if self.verbose:
             print(f'Using SQL query:\n\n-------\n\n{query}\n\n-------\n\n')
@@ -249,21 +291,3 @@ class Postserve:
         print(f"Postserve started, listening on 0.0.0.0:{self.port}")
         print(f"Use {self.url} as the data source")
         IOLoop.instance().start()
-
-
-async def get_sql_types(connection: Connection):
-    """
-    Get Postgres types that we can handle,
-    and return the mapping of OSM type id (oid) => MVT style type
-    """
-    sql_to_mvt_types = dict(
-        bool="Boolean",
-        text="String",
-        int4="Number",
-        int8="Number",
-    )
-    types = await connection.fetch(
-        "select oid, typname from pg_type where typname = ANY($1::text[])",
-        list(sql_to_mvt_types.keys())
-    )
-    return {row['oid']: sql_to_mvt_types[row['typname']] for row in types}

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Union, Dict, Any, Callable
 
+import json
 import sys
 import yaml
 from deprecated import deprecated


### PR DESCRIPTION
`meta-generate` - populates mbtiles metadata table from tileset and PostgreSQL DB,
with optional env var overrides.

`meta-copy` - copies all metadata values from one mbtile to another, optionally updating some values.

Also refactors and cleans up postserve metadata to confirm to spec.