### PR TITLE
Support test-perf bbox tests

### DIFF
--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -45,6 +45,37 @@ TEST_CASES: Dict[str, TestCase] = {v.id: v for v in [
         'null',
         'Empty set, useful for query validation.',
         (0, 0), (0, 0)),  # DO NOT CHANGE THESE COORDINATES
+
+    # Smallest Geofabrik areas, smallest to largest (in PBF MBs)
+    TestCase('monaco', 'Monaco (Europe)',
+             bbox='7.4016843,43.5165358,7.5002447,43.7543525'),
+    # saint-helena-ascension-and-tristan-da-cunha has 2,519,538 tiles, skipping
+    TestCase('sao-tome-and-principe', 'Sao Tome and Principe (Africa)',
+             bbox='6.2606420,-0.2135137,7.6704783,1.9257601'),
+    TestCase('rutland', 'Rutland (Europe/England)',
+             bbox='-0.8754549,52.2185243,-0.2619499,53.2289705'),
+    TestCase('andorra', 'Andorra (Europe)',
+             bbox='0.9755770,42.3242153,1.8246545,42.7883379'),
+    TestCase('equatorial-guinea', 'Equatorial Guinea (Africa)',
+             bbox='5.4172943,-1.6732196,12.3733400,4.3475256'),
+    TestCase('liechtenstein', 'Liechtenstein (Europe)',
+             bbox='9.0900979,46.9688169,9.6717077,47.5258072'),
+    TestCase('isle-of-man', 'Isle of Man (Europe)',
+             bbox='-20.0516670,52.0363391,-2.9134845,55.7175267'),
+    TestCase('seychelles', 'Seychelles (Africa)',
+             bbox='44.7888890,-12.8022220,56.4979396,-3.5120000'),
+    TestCase('enfield', 'Enfield (Europe, England, London)',
+             bbox='-0.3411928,51.5711773,0.0420140,51.7314462'),
+    TestCase('comores', 'Comores (Africa)',
+             bbox='43.0253050,-12.7197220,45.7675000,-10.9803547'),
+    TestCase('maldives', 'Maldives (Asia)',
+             bbox='51.0378745,-0.9074935,80.5838734,25.6240842'),
+    TestCase('faroe-islands', 'Faroe Islands (Europe)',
+             bbox='-14.0036840,57.5958843,9.9757588,65.3045646'),
+    TestCase('mayotte', 'Mayotte (Europe, France)',
+             bbox='44.7436676,-13.2732554,45.5070347,-12.3485200'),
+    TestCase('malta', 'Malta (Europe)',
+             bbox='5.3397500,31.2100000,29.9100000,42.9466000'),
 ]}
 
 

--- a/openmaptiles/perfutils.py
+++ b/openmaptiles/perfutils.py
@@ -10,7 +10,7 @@ from ascii_graph import Pyasciigraph
 # noinspection PyUnresolvedReferences
 from dataclasses_json import dataclass_json, config
 
-from openmaptiles.utils import round_td
+from openmaptiles.utils import round_td, Bbox, deg2num
 
 
 class Colors:
@@ -167,9 +167,16 @@ class TestCase:
     query: str = None
     old_result: PerfTestSummary = None
     result: PerfTestSummary = None
+    bbox: str = None
 
     def __post_init__(self):
         assert self.id and self.desc
+        if self.start is None and self.before is None and self.bbox is not None:
+            bbox = Bbox(self.bbox)
+            self.start = deg2num(bbox.max_lat, bbox.min_lon, self.zoom)
+            self.before = deg2num(bbox.min_lat, bbox.max_lon, self.zoom)
+            self.before = (self.before[0] + 1, self.before[1] + 1)
+
         assert isinstance(self.start, tuple) and isinstance(self.before, tuple)
         assert len(self.start) == 2 and len(self.before) == 2
         assert self.start[0] <= self.before[0] and self.start[1] <= self.before[1]
@@ -202,7 +209,7 @@ class TestCase:
         if self.size() > 0:
             pos = f" [{self.start[0]}/{self.start[1]}]" \
                   f"x[{self.before[0] - 1}/{self.before[1] - 1}]"
-        return f"* {self.id:10} {self.desc} ({self.size():,} " \
+        return f"* {self.id:30} {self.desc} ({self.size():,} " \
                f"tiles at z{self.zoom}{pos})"
 
     def format(self) -> str:

--- a/openmaptiles/utils.py
+++ b/openmaptiles/utils.py
@@ -1,3 +1,5 @@
+import math
+
 import asyncio
 import re
 import sys
@@ -17,6 +19,15 @@ def coalesce(*args):
         if v is not None:
             return v
     return None
+
+
+# From https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Lon..2Flat._to_tile_numbers_2
+def deg2num(lat_deg, lon_deg, zoom):
+    lat_rad = math.radians(lat_deg)
+    n = 2.0 ** zoom
+    tile_x = int((lon_deg + 180.0) / 360.0 * n)
+    tile_y = int((1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n)
+    return tile_x, tile_y
 
 
 class Bbox:


### PR DESCRIPTION
Add test-perf support for defining tests as BBOX rather than tile boxes.
This PR also adds a number of small areas.

I am not yet sure we should add all of the hardcoded tests, TBD.