### PR TITLE
Allow any bbox(es) in test-perf util

### DIFF
--- a/bin/test-perf
+++ b/bin/test-perf
@@ -4,7 +4,7 @@ Evaluate tile generation performance against a PostgreSQL database.
 
 Usage:
   test-perf <tileset> [--test=<set>]... [--layer=<layer>]... [--exclude-layers]
-              [--per-layer] [--summary] [--test-all]
+              [--per-layer] [--summary] [--test-all] [--bbox=<bbox>]...
               ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
               [--record=<file>] [--compare=<file>] [--buckets=<count>]
               [--key] [--gzip [<gzlevel>]] [--no-color] [--no-feature-ids]
@@ -18,9 +18,12 @@ Usage:
   <tileset>             Tileset definition yaml file
 
 Options:
-  -t --test=<set>       Which predefined test to run.  [default: us-across]
-                        Use invalid value to see a list.  Use 'null' for PostGIS < v2.5
+  -t --test=<set>       Which predefined test to run, default is us-across unless --bbox
+                        or --test-all are set. Use invalid value to see a list.
+                        Use 'null' for PostGIS < v2.5
   -a --test-all         Run all available tests except 'null'
+  -o --bbox=<bbox>      Provide one or more custom test areas in BBOX format:
+                          comma-separated geo coordinates - <left,bottom,right,top>
   -p --per-layer        Test each layer individually, also show per-layer summary graph.
   -s --summary          Run summary tests, without per-tile break-down.
   -l --layer=<layers>   Limit testing to a specific layer (could be more than one)
@@ -67,10 +70,16 @@ def main(args):
     if not zooms:
         zooms = list(range(int(args['--minzoom']), int(args['--maxzoom']) + 1))
     pghost, pgport, dbname, user, password = parse_pg_args(args)
+
+    tests = args['--test']
+    if not tests and not args['--test-all'] and not args['--bbox']:
+        tests = ["us-across"]
+
     perf = PerfTester(
         tileset=args['<tileset>'],
-        tests=args['--test'],
+        tests=tests,
         test_all=args['--test-all'],
+        bboxes=args['--bbox'],
         summary=args['--summary'],
         per_layer=args['--per-layer'],
         layers=args['--layer'],

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -89,8 +89,8 @@ class PerfTester:
                  zooms: List[int], dbname: str, pghost, pgport: str, user: str,
                  password: str, summary: bool, per_layer: bool, buckets: int,
                  save_to: Union[None, str, Path], compare_with: Union[None, str, Path],
-                 key_column: bool, gzip: bool, disable_feature_ids: bool = None,
-                 exclude_layers: bool = False, verbose: bool = None):
+                 key_column: bool, gzip: bool, disable_feature_ids: bool,
+                 exclude_layers: bool, verbose: bool, bboxes: List[str]):
         self.tileset = Tileset.parse(tileset)
         self.dbname = dbname
         self.pghost = pghost
@@ -116,14 +116,22 @@ class PerfTester:
         else:
             self.old_run = None
 
+        self.all_test_cases = TEST_CASES.copy()
+
+        # Fake bbox tests as if they were defined, and create names for them
+        for bbox_idx, bbox in enumerate(bboxes, start=1):
+            tc = TestCase(f'bbox_test_{bbox_idx}', bbox, bbox=bbox)
+            self.all_test_cases[tc.id] = tc
+            tests.append(tc.id)
+
         for test in tests:
-            if test not in TEST_CASES:
-                cases = '\n'.join(map(TestCase.fmt_table, TEST_CASES.values()))
+            if test not in self.all_test_cases:
+                cases = '\n'.join(map(TestCase.fmt_table, self.all_test_cases.values()))
                 raise DocoptExit(f"Test '{test}' is not defined. "
                                  f"Available tests are:\n{cases}\n")
         if test_all:
             # Do this after validating individual tests, they are ignored but validated
-            tests = [v for v in TEST_CASES.keys() if v != 'null']
+            tests = [v for v in self.all_test_cases.keys() if v != 'null']
         all_layers = [v.id for v in self.tileset.layers]
         if layers and exclude_layers:
             # inverse layers list
@@ -205,7 +213,7 @@ SELECT {prefix}(COALESCE(LENGTH(({query})), 0)) AS len FROM
 generate_series(CAST($2 as int), CAST($3 as int)) AS xval(x),
 generate_series(CAST($4 as int), CAST($5 as int)) AS yval(y);
 """
-        return TEST_CASES[test].make_test(zoom, layers, query)
+        return self.all_test_cases[test].make_test(zoom, layers, query)
 
     async def run_test(self, conn: Connection, test: TestCase):
         results = []

--- a/openmaptiles/performance.py
+++ b/openmaptiles/performance.py
@@ -274,8 +274,8 @@ generate_series(CAST($4 as int), CAST($5 as int)) AS yval(y);
 
         old_buckets = old and old.buckets or []
         print_graph(
-            f"Tile size distribution for {test.tiles:,} tiles "
-            f"(~{test.tiles / buckets:.0f}/line) generated in "
+            f"Tile sizes for {test.tiles:,} tiles "
+            f"(~{test.tiles / buckets:.0f}/line) done in "
             f"{round_td(test.result.duration)} "
             f"({test.result.gen_speed:,.1f} tiles/s"
             f"{change(old.gen_speed, test.result.gen_speed, True) if old else ''})",

--- a/openmaptiles/perfutils.py
+++ b/openmaptiles/perfutils.py
@@ -14,7 +14,7 @@ from openmaptiles.utils import round_td, Bbox, deg2num
 
 # If the terminal is not present, use this width
 # In github, comments inside the ``` block are about 88 characters
-DEFAULT_TERMINAL_WIDTH = 80
+DEFAULT_TERMINAL_WIDTH = 87
 
 
 class Colors:
@@ -125,10 +125,10 @@ class PerfBucket:
         else:
             delta = ''
             color = None
-        msg = f"avg tile size" \
+        msg = f"avg size" \
               f"{delta}, " \
-              f"{self.smallest_size:,} B ({self.smallest_id}) — " \
-              f"{self.largest_size:,} B ({self.largest_id})"
+              f"{self.smallest_size:,}B ({self.smallest_id}) — " \
+              f"{self.largest_size:,}B ({self.largest_id})"
         if color:
             return msg, self.tile_avg_size, color
         else:


### PR DESCRIPTION
This will allow a much more flexible profiling testing with custom data sets.