### PR TITLE
Create directory for state file, if needed

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -387,6 +387,7 @@ async def save_state_file(session, state_url, state_file):
     state_file = Path(state_file).resolve()
     print(f"Downloading state file {state_url} to {state_file}")
     data = await fetch(session, state_url)
+    state_file.parent.mkdir(exist_ok=True)
     state_file.write_text(data, encoding="utf-8")
 
 


### PR DESCRIPTION
Similar to https://github.com/openmaptiles/openmaptiles-tools/blob/8861aa800263aa6cb4b679e436b0a3e0b78ba2c3/bin/download-osm#L339

Avoid errors like
```
Downloading state file http://download.openstreetmap.fr/extracts/...state.txt to /import/replication/last.state.txt
Traceback (most recent call last):
  File "/usr/src/app/download-osm", line 664, in <module>
    main()
  File "/usr/src/app/download-osm", line 660, in main
    exit(asyncio.run(main_async(docopt(__doc__, version=openmaptiles.__version__))))
  File "/usr/local/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/src/app/download-osm", line 547, in main_async
    urls, md5, area_id, repl_url = await prepare_area_download(args, session)
  File "/usr/src/app/download-osm", line 433, in prepare_area_download
    await save_state_file(session, state_url, args.state)
  File "/usr/src/app/download-osm", line 390, in save_state_file
    state_file.write_text(data, encoding="utf-8")
  File "/usr/local/lib/python3.8/pathlib.py", line 1246, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors) as f:
  File "/usr/local/lib/python3.8/pathlib.py", line 1213, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/usr/local/lib/python3.8/pathlib.py", line 1069, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/import/replication/last.state.txt'
Makefile:137: recipe for target 'download-osmfr' failed
make: *** [download-osmfr] Error 1
```