### PR TITLE
Improve the speed of CleanNumeric

### DIFF
--- a/sql/CleanNumeric.sql
+++ b/sql/CleanNumeric.sql
@@ -11,10 +11,8 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text) returns numeric as
 $body$
-begin
-    return substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$')::numeric;
-end;
+ SELECT substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$')::numeric;
 $body$
-language plpgsql
+language sql
 strict immutable cost 20
 parallel safe;


### PR DESCRIPTION
Use sql instead of plpgsql - order of magnitude improvements!
Used the new func performance tool - https://github.com/openmaptiles/openmaptiles-tools/pull/263

Comparing for https://github.com/openmaptiles/openmaptiles/pull/858 :
* `nullif(as_numeric('1'),-1)` -- that's how it is being done now
* `CleanNumericO('1')` -- that's the old version of the `CleanNumeric`
* `CleanNumeric('1')` --that's the new version

For the test below, I modified functions to be `strict volatile` -- so that results for the same value won't be cached.

```
Function                    AVG of 8 runs    MIN             MAX                   STDEV
--------------------------  ---------------  --------------  --------------  -----------
nullif(as_numeric('1'),-1)  0:00:00.297897   0:00:00.294280  0:00:00.302205  0.00308608
nullif(as_numeric('a'),-1)  0:00:01.087890   0:00:01.070349  0:00:01.131548  0.0216968
CleanNumericO('1')          0:00:00.666679   0:00:00.647790  0:00:00.694018  0.0198286
CleanNumericO('a')          0:00:00.303755   0:00:00.292559  0:00:00.338983  0.0166885
CleanNumeric('1')           0:00:00.025618   0:00:00.025023  0:00:00.026306  0.000502295
CleanNumeric('a')           0:00:00.025074   0:00:00.024795  0:00:00.025883  0.000393131
```

When running tests without marking them as volatile, the results are much less meaningful:

```
Function                    AVG of 8 runs    MIN             MAX                   STDEV
--------------------------  ---------------  --------------  --------------  -----------
nullif(as_numeric('1'),-1)  0:00:00.025103   0:00:00.023454  0:00:00.031265  0.00269194
nullif(as_numeric('a'),-1)  0:00:00.025701   0:00:00.023873  0:00:00.034054  0.00340228
CleanNumericO('1')          0:00:00.023108   0:00:00.022630  0:00:00.024790  0.000735316
CleanNumericO('a')          0:00:00.024221   0:00:00.022702  0:00:00.032164  0.00329418
CleanNumeric('1')           0:00:00.024390   0:00:00.023019  0:00:00.029902  0.00226324
CleanNumeric('a')           0:00:00.022912   0:00:00.022606  0:00:00.023515  0.000344841
```