### PR TITLE
Improve the speed of LineLabel

### DIFF
--- a/sql/LineLabel.sql
+++ b/sql/LineLabel.sql
@@ -21,17 +21,14 @@ create or replace function LineLabel (
         g geometry
     )
     returns boolean
-    language plpgsql immutable
+    language sql immutable
     parallel safe as
 $func$
-begin
-    if zoom > 20 or ST_Length(g) = 0 then
+    SELECT CASE
         -- if length is 0 geom is (probably) a point; keep it
-        return true;
-    else
-        return length(label) between 1 and ST_Length(g)/(2^(20-zoom));
-    end if;
-end;
+        WHEN zoom > 20 or ST_Length(g) = 0 THEN true
+        ELSE length(label) between 1 and ST_Length(g)/(2^(20-zoom))
+    END;
 $func$;
 
 


### PR DESCRIPTION
Use sql instead of plpgsql - 20x improvements!

For testing, modified the old `LineLabelO` and the new `LineLabel` declaration to `volatile` instead of `immutable` to avoid PG caching results.

```
Function                                                                    AVG of 8 runs    MIN             MAX                  STDEV
--------------------------------------------------------------------------  ---------------  --------------  --------------  ----------
LineLabelO(14, 'Foobar', ST_GeomFromText('POINT(0 0)',900913))              0:00:00.368460   0:00:00.293127  0:00:00.410502  0.0484709
LineLabel(14, 'Foobar', ST_GeomFromText('POINT(0 0)',900913))               0:00:00.037778   0:00:00.029171  0:00:00.042144  0.00538044
LineLabel(15, 'Foobar', ST_GeomFromText('LINESTRING(0 0, 0 300)',900913))   0:00:00.038002   0:00:00.028599  0:00:00.042815  0.00515147
LineLabelO(15, 'Foobar', ST_GeomFromText('LINESTRING(0 0, 0 300)',900913))  0:00:00.634959   0:00:00.513933  0:00:00.732014  0.0975762
```