### PR TITLE
add protoc to go-builder in tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux ;\
         libgeos-dev \
         libleveldb-dev \
         libprotobuf-dev \
+        protobuf-compiler \
         ;\
     \
     apt list --installed ;\


### PR DESCRIPTION
When building go apps, it sometimes does not install `protoc` compiler. Adding `protobuf-compiler` dependency should solve that.