### PR TITLE
Cleanup postgis docker, bump osml10n ver

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -2,18 +2,27 @@
 # the postgis base image has outdated ogr2ogr (gdal-bin package)
 # does not support PG12 yet, which means postgis-preloaded cannot be built easily.
 # Once it is updated, or there is a different way to build it, we can upgrade to 12.
-FROM postgis/postgis:9.6-3.0
+ARG BASE_POSTGIS_VER=9.6-3.0
+FROM postgis/postgis:$BASE_POSTGIS_VER
 
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
-ENV UTF8PROC_TAG=v2.5.0 \
-    MAPNIK_GERMAN_L10N_TAG=v2.5.8 \
-    PGSQL_GZIP_HASH=v1.0.0
 
-RUN apt-get -qq -y update \
+# https://github.com/pramsey/pgsql-gzip/releases
+ARG PGSQL_GZIP_TAG=v1.0.0
+
+# https://github.com/JuliaLang/utf8proc/releases
+ARG UTF8PROC_TAG=v2.5.0
+
+# osml10n - https://github.com/giggls/mapnik-german-l10n/releases
+ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9
+
+
+RUN set -eux  ;\
+    apt-get -qq -y update  ;\
     ##
     ## Install build dependencies
-    && apt-get -qq -y --no-install-recommends install \
+    apt-get -qq -y --no-install-recommends install \
         build-essential \
         ca-certificates \
         # Required by Nominatim to download data files
@@ -24,37 +33,35 @@ RUN apt-get -qq -y update \
         postgresql-server-dev-$PG_MAJOR \
         libkakasi2-dev \
         libgdal-dev \
+    ;\
     ##
     ## gzip extension
-    && cd /opt/ \
-    && git clone https://github.com/pramsey/pgsql-gzip.git \
-    && cd pgsql-gzip \
-    && git checkout -q $PGSQL_GZIP_HASH \
-    && make \
-    && make install \
-    && rm -rf /opt/pgsql-gzip \
+    cd /opt/  ;\
+    git clone --quiet --depth 1 -b $PGSQL_GZIP_TAG https://github.com/pramsey/pgsql-gzip.git  ;\
+    cd pgsql-gzip  ;\
+    make  ;\
+    make install  ;\
+    rm -rf /opt/pgsql-gzip  ;\
     ##
     ## UTF8Proc
-    && cd /opt/ \
-    && git clone https://github.com/JuliaLang/utf8proc.git \
-    && cd utf8proc \
-    && git checkout -q $UTF8PROC_TAG \
-    && make \
-    && make install \
-    && ldconfig \
-    && rm -rf /opt/utf8proc \
+    cd /opt/  ;\
+    git clone --quiet --depth 1 -b $UTF8PROC_TAG https://github.com/JuliaLang/utf8proc.git  ;\
+    cd utf8proc  ;\
+    make  ;\
+    make install  ;\
+    ldconfig  ;\
+    rm -rf /opt/utf8proc  ;\
     ##
     ## osml10n extension (originally Mapnik German)
-    && cd /opt/ \
-    && git clone https://github.com/giggls/mapnik-german-l10n.git \
-    && cd mapnik-german-l10n \
-    && git checkout -q $MAPNIK_GERMAN_L10N_TAG \
-    && make \
-    && make install \
-    && rm -rf /opt/mapnik-german-l10n \
+    cd /opt/  ;\
+    git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG https://github.com/giggls/mapnik-german-l10n.git  ;\
+    cd mapnik-german-l10n  ;\
+    make  ;\
+    make install  ;\
+    rm -rf /opt/mapnik-german-l10n  ;\
     ##
     ## Cleanup
-    && apt-get -qq -y --auto-remove purge \
+    apt-get -qq -y --auto-remove purge \
         autoconf \
         automake \
         autotools-dev \
@@ -80,8 +87,9 @@ RUN apt-get -qq -y update \
         libxml2-dev \
         libjson-c-dev \
         libgdal-dev \
-    && rm -rf /usr/local/lib/*.a \
-    && rm -rf /var/lib/apt/lists/*
+    ;\
+    rm -rf /usr/local/lib/*.a  ;\
+    rm -rf /var/lib/apt/lists/*
 
 # The script should run after the parent's 10_postgis.sh runs
 # so it must have the name that's listed after that.

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -7,15 +7,17 @@ FROM postgis/postgis:$BASE_POSTGIS_VER
 
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
-
 # https://github.com/pramsey/pgsql-gzip/releases
 ARG PGSQL_GZIP_TAG=v1.0.0
+ARG PGSQL_GZIP_REPO=https://github.com/pramsey/pgsql-gzip.git
 
 # https://github.com/JuliaLang/utf8proc/releases
 ARG UTF8PROC_TAG=v2.5.0
+ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
 # osml10n - https://github.com/giggls/mapnik-german-l10n/releases
 ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9
+ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/giggls/mapnik-german-l10n.git
 
 
 RUN set -eux  ;\
@@ -37,7 +39,7 @@ RUN set -eux  ;\
     ##
     ## gzip extension
     cd /opt/  ;\
-    git clone --quiet --depth 1 -b $PGSQL_GZIP_TAG https://github.com/pramsey/pgsql-gzip.git  ;\
+    git clone --quiet --depth 1 -b $PGSQL_GZIP_TAG $PGSQL_GZIP_REPO  ;\
     cd pgsql-gzip  ;\
     make  ;\
     make install  ;\
@@ -45,7 +47,7 @@ RUN set -eux  ;\
     ##
     ## UTF8Proc
     cd /opt/  ;\
-    git clone --quiet --depth 1 -b $UTF8PROC_TAG https://github.com/JuliaLang/utf8proc.git  ;\
+    git clone --quiet --depth 1 -b $UTF8PROC_TAG $UTF8PROC_REPO  ;\
     cd utf8proc  ;\
     make  ;\
     make install  ;\
@@ -54,7 +56,7 @@ RUN set -eux  ;\
     ##
     ## osml10n extension (originally Mapnik German)
     cd /opt/  ;\
-    git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG https://github.com/giggls/mapnik-german-l10n.git  ;\
+    git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG $MAPNIK_GERMAN_L10N_REPO  ;\
     cd mapnik-german-l10n  ;\
     make  ;\
     make install  ;\


### PR DESCRIPTION
* Upgrade osml10n v2.5.8 to the faster v2.5.9
* parametrize base image version
* use ARG instead of ENV to for the repo tags
* faster build - `git clone` now downloads just a single tag without history
* Use cleaner multiline syntax