### PR TITLE
Add openmaptiles-tools to generated DC file

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -629,17 +629,20 @@ def make_docker_compose_file(pbf_file: Path, dc_file: Path,
         lat_min = res["lat min"]
         lat_max = res["lat max"]
         timestamp_max = res["timestamp max"]
+        env_values = {
+            "environment": {
+                "BBOX": f"{lon_min},{lat_min},{lon_max},{lat_max}",
+                "OSM_MAX_TIMESTAMP": timestamp_max,
+                "OSM_AREA_NAME": area or pbf_file.name.split('.', 1)[0],
+                "MIN_ZOOM": min_zoom,
+                "MAX_ZOOM": max_zoom,
+            }}
         dc_data = {
             "version": str(dc_ver),
             "services": {
-                "generate-vectortiles": {
-                    "environment": {
-                        "BBOX": f"{lon_min},{lat_min},{lon_max},{lat_max}",
-                        "OSM_MAX_TIMESTAMP": timestamp_max,
-                        "OSM_AREA_NAME": area or pbf_file.name.split('.', 1)[0],
-                        "MIN_ZOOM": min_zoom,
-                        "MAX_ZOOM": max_zoom,
-                    }}}}
+                "openmaptiles-tools": env_values,
+                "generate-vectortiles": env_values,
+            }}
         print(f"Saving metadata to {dc_file}...")
         with dc_file.open('w') as yaml_file:
             yaml.dump(dc_data, yaml_file, sort_keys=False)

--- a/tests/expected/monaco-dc.yml
+++ b/tests/expected/monaco-dc.yml
@@ -1,9 +1,10 @@
 version: '2.0'
 services:
-  generate-vectortiles:
+  openmaptiles-tools: &id001
     environment:
       BBOX: 7.3830115,43.5163330,7.5003330,43.7543525
       OSM_MAX_TIMESTAMP: '2015-04-27T19:32:23Z'
       OSM_AREA_NAME: raw-url
       MIN_ZOOM: 0
       MAX_ZOOM: 10
+  generate-vectortiles: *id001

--- a/tests/expected/monaco-dc2.yml
+++ b/tests/expected/monaco-dc2.yml
@@ -1,9 +1,10 @@
 version: '2.2'
 services:
-  generate-vectortiles:
+  openmaptiles-tools: &id001
     environment:
       BBOX: 7.3830115,43.5163330,7.5003330,43.7543525
       OSM_MAX_TIMESTAMP: '2015-04-27T19:32:23Z'
       OSM_AREA_NAME: monaco-test2
       MIN_ZOOM: 3
       MAX_ZOOM: 5
+  generate-vectortiles: *id001

--- a/tests/expected/monaco-dc3.yml
+++ b/tests/expected/monaco-dc3.yml
@@ -1,9 +1,10 @@
 version: '2.1'
 services:
-  generate-vectortiles:
+  openmaptiles-tools: &id001
     environment:
       BBOX: 7.3830115,43.5163330,7.5003330,43.7543525
       OSM_MAX_TIMESTAMP: '2015-04-27T19:32:23Z'
       OSM_AREA_NAME: europe/monaco-test
       MIN_ZOOM: 5
       MAX_ZOOM: 6
+  generate-vectortiles: *id001


### PR DESCRIPTION
When `download-osm` generates docker compose file,
it needs to set values for both openmaptiles-tools and generate-vectortiles
targets - so that both can use auto-generated values like BBOX