### PR TITLE
install nano in tools container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ RUN set -eux ;\
         wget \
         git  \
         less \
+        nano \
         gnupg2  `# TODO: not sure why gnupg2 is needed`  ;\
     curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ;\
     /bin/bash -c 'source /etc/os-release && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME:?}-pgdg main ${PG_MAJOR:?}" > /etc/apt/sources.list.d/pgdg.list' ;\


### PR DESCRIPTION
tools often need simple editing done inside the tools container for debugging purposes,
and vim is much bigger than nano