### PR TITLE
download-osm fix missing "timestamp max"

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -630,7 +630,7 @@ def make_docker_compose_file(pbf_file: Path, dc_file: Path,
         lon_max = res["lon max"]
         lat_min = res["lat min"]
         lat_max = res["lat max"]
-        timestamp_max = res["timestamp max"]
+        timestamp_max = res["timestamp max"] if "timestamp max" in res else None
         env_values = {
             "environment": {
                 "BBOX": f"{lon_min},{lat_min},{lon_max},{lat_max}",
@@ -639,6 +639,9 @@ def make_docker_compose_file(pbf_file: Path, dc_file: Path,
                 "MIN_ZOOM": min_zoom,
                 "MAX_ZOOM": max_zoom,
             }}
+        if timestamp_max is None:
+            # Deleting is better than adding because it keeps key ordering intact
+            del env_values["environment"]["OSM_MAX_TIMESTAMP"]
         dc_data = {
             "version": str(dc_ver),
             "services": {


### PR DESCRIPTION
During make-dc command, there could be a case when `timestamp max` does not get printed
by the osmconvert's statistics output. Handle such case, and simply remove
the `OSM_MAX_TIMESTAMP` from the generated docker compose file.