### PR TITLE
New layer-stats tool to explore data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenMapTiles Tools ![Build and publish to Docker](https://github.com/openmaptiles/openmaptiles-tools/workflows/Build%20and%20publish%20to%20Docker/badge.svg)
 
 The OpenMapTiles toolbox for generating map vector tiles.
-It includes tools to prepare Imposm mappings and SQL files based on layers defined in [OpenMapTiles](https://github.com/openmaptiles/openmaptiles) or similar projects. It also includes map data downloading, parsing, debugging, and performance evaluation tools. 
+It includes tools to prepare Imposm mappings and SQL files based on layers defined in [OpenMapTiles](https://github.com/openmaptiles/openmaptiles) or similar projects. It also includes map data downloading, parsing, debugging, and performance evaluation tools.
 We encourage other people to use this for their vector tile projects as well since this approach works well for us.
 
 ## Docker Images
@@ -19,7 +19,7 @@ The above `postgis` image pre-loaded with the `import-data`. This image is mostl
 
 
 ##### generate-vectortiles [![](https://img.shields.io/microbadger/layers/openmaptiles/generate-vectortiles)](https://hub.docker.com/r/openmaptiles/generate-vectortiles) [![](https://img.shields.io/microbadger/image-size/openmaptiles/generate-vectortiles?label=size)](https://hub.docker.com/r/openmaptiles/generate-vectortiles) [![](https://img.shields.io/docker/pulls/openmaptiles/generate-vectortiles?label=downloads)](https://hub.docker.com/r/openmaptiles/generate-vectortiles) [![](https://img.shields.io/docker/stars/openmaptiles/generate-vectortiles?label=stars)](https://hub.docker.com/r/openmaptiles/generate-vectortiles)
-Legacy Mapnik-based image that simplifies `tilelive-copy` tile generation.  Eventually will be replaced with PostgreSQL-based [ST_AsMVT](https://postgis.net/docs/ST_AsMVT.html) approach. 
+Legacy Mapnik-based image that simplifies `tilelive-copy` tile generation.  Eventually will be replaced with PostgreSQL-based [ST_AsMVT](https://postgis.net/docs/ST_AsMVT.html) approach.
 
 
 ## Usage
@@ -256,6 +256,12 @@ $ debug-mvt openmaptiles.yaml 4/7/6 -l place
 ### Profile PostgreSQL functions
 Use `profile-pg-func` to compare PostgreSQL function execution speed. Each function is called thousands of times in several runs. The fastest and slowest runs are discarded.  `profile-pg-func` can import SQL files before running the test, e.g. to add the latest developer versions of the function(s).
 
+### Show layer statistics for a field
+Use `layer-stats` show per zoom statistics for some column (field) in a single layer. Supports several metrics:
+* `frequency` - Shows how often each unique value occurs in a layer's column or combination of columns.
+* `toplength` - Shows the longest N values for a given layer's column.
+* `variance` - Shows a few statistical metrics for a column's numeric value.
+
 ## Tools
 
 ### Environment variables
@@ -291,7 +297,7 @@ download-osm planet -- -d ./downloads
 # download New Zealand extract from Geofabrik, together with the state file
 download-osm geofabrik new-zealand --state state.txt
 
-# List all extracts available from Geofabrik 
+# List all extracts available from Geofabrik
 download-osm list geofabrik
 ```
 

--- a/bin/debug-mvt
+++ b/bin/debug-mvt
@@ -43,11 +43,14 @@ Options:
   --version             Show version.
 
 PostgreSQL Options:
-  -h --pghost=<host>    Postgres hostname. By default uses POSTGRES_HOST env or "localhost" if not set.
-  -P --pgport=<port>    Postgres port. By default uses POSTGRES_PORT env or "5432" if not set.
-  -d --dbname=<db>      Postgres db name. By default uses POSTGRES_DB env or "openmaptiles" if not set.
-  -U --user=<user>      Postgres user. By default uses POSTGRES_USER env or "openmaptiles" if not set.
-  --password=<password> Postgres password. By default uses POSTGRES_PASSWORD env or "openmaptiles" if not set.
+  -h --pghost=<host>    Postgres hostname. By default uses PGHOST env or "localhost" if not set.
+  -P --pgport=<port>    Postgres port. By default uses PGPORT env or "5432" if not set.
+  -d --dbname=<db>      Postgres db name. By default uses PGDATABASE env or "openmaptiles" if not set.
+  -U --user=<user>      Postgres user. By default uses PGUSER env or "openmaptiles" if not set.
+  --password=<password> Postgres password. By default uses PGPASSWORD env or "openmaptiles" if not set.
+
+These legacy environment variables should not be used, but they are still supported:
+  POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
 """
 import asyncio
 import gzip
@@ -61,7 +64,8 @@ from tabulate import tabulate
 from time import time
 
 import openmaptiles
-from openmaptiles.pgutils import parse_pg_args, get_postgis_version, PgWarnings
+from openmaptiles.pgutils import parse_pg_args, get_postgis_version, PgWarnings, \
+    print_query_error
 from openmaptiles.sqltomvt import MvtGenerator
 from openmaptiles.tileset import Tileset
 from openmaptiles.utils import parse_zxy_param, print_tile
@@ -136,16 +140,8 @@ async def main(args):
             took = time() - start_ts
         except asyncpg.PostgresError as err:
             took = time() - start_ts
-            msg = f"####### ERROR getting tile {zoom}/{x}/{y} ({took:.2f}s) #######"
-            line = '#' * len(msg)
-            print(f"{line}\n{msg}\n{line}\n{err.__class__.__name__}: {err}")
-            if hasattr(err, "context") and err.context:
-                print(f"context: {err.context}")
-            pg_warnings.print()
-            if not verbose:
-                # Always print failed SQL
-                print(f"\n== FULL QUERY\n{query.strip()}")
-            print(f"{line}\n")
+            print_query_error(f"ERROR getting tile {zoom}/{x}/{y} ({took:.2f}s)",
+                              err, pg_warnings, verbose, query)
             return
         if result:
             mvt_data = result['mvt']
@@ -230,16 +226,8 @@ async def main(args):
             fields = ','.join(columns) if columns else '*'
             query_result = await conn.fetch(f"SELECT {fields} FROM {query}")
         except asyncpg.PostgresError as err:
-            msg = f"####### ERROR in {layer_id} layer #######"
-            line = '#' * len(msg)
-            print(f"{line}\n{msg}\n{line}\n{err.__class__.__name__}: {err}")
-            if hasattr(err, "context") and err.context:
-                print(f"context: {err.context}")
-            pg_warnings.print()
-            if not verbose:
-                # Always print failed SQL
-                print(f"\n== FULL QUERY\n{query.strip()}\n\n== MVT SQL\n{layer_sql}")
-            print(f"{line}\n")
+            print_query_error(f"ERROR in {layer_id} layer", err, pg_warnings, verbose,
+                              query, layer_sql)
             continue
 
         result = []

--- a/bin/layer-stats
+++ b/bin/layer-stats
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+"""
+Shows per-layer statistics in a database.
+
+Usage:
+  layer-stats frequency <tileset> <layer> <column>...
+              ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
+              [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+              [--user=<user>] [--password=<password>] [--verbose]
+  layer-stats toplength <tileset> <layer> <column> [--max-count=<c>]
+              ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
+              [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+              [--user=<user>] [--password=<password>] [--verbose]
+  layer-stats variance <tileset> <layer> <column>
+              ([--zoom=<zoom>]... | [--minzoom=<min>] [--maxzoom=<max>])
+              [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
+              [--user=<user>] [--password=<password>] [--verbose]
+  layer-stats --help
+  layer-stats --version
+
+Methods:
+  frequency             Shows how often each unique value occurs in a layer's column.
+                        If more than one column is given, shows unique combinations.
+  toplength             Shows the longest N values for a given layer's column.
+  variance              Shows a few statistical metrics for a column's numeric value.
+
+Options:
+  <tileset>             Tileset definition yaml file
+  <column>              Columns to analyze, could be more than one.
+  <layer>               Which layer to examine
+  -z --zoom=<zoom>      Limit testing to a specific zoom. If set, ignores min/max.
+  -m --minzoom=<min>    Test tiles in zooms more or equal to this value  [default: 0]
+  -n --maxzoom=<max>    Test tiles in zooms less or equal to this value  [default: 14]
+  --max-count=<max>     For toplength, how many longest values to show [default: 30]
+  -v --verbose          Print additional debugging information
+  --help                Show this screen.
+  --version             Show version.
+
+PostgreSQL Options:
+  -h --pghost=<host>    Postgres hostname. By default uses PGHOST env or "localhost" if not set.
+  -P --pgport=<port>    Postgres port. By default uses PGPORT env or "5432" if not set.
+  -d --dbname=<db>      Postgres db name. By default uses PGDATABASE env or "openmaptiles" if not set.
+  -U --user=<user>      Postgres user. By default uses PGUSER env or "openmaptiles" if not set.
+  --password=<password> Postgres password. By default uses PGPASSWORD env or "openmaptiles" if not set.
+
+These legacy environment variables should not be used, but they are still supported:
+  POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
+"""
+import asyncio
+import re
+from collections import defaultdict
+
+import asyncpg
+# noinspection PyProtectedMember
+from docopt import docopt, DocoptExit
+from tabulate import tabulate
+
+import openmaptiles
+from openmaptiles.pgutils import parse_pg_args, get_postgis_version, PgWarnings, \
+    print_query_error
+from openmaptiles.sqltomvt import MvtGenerator
+from openmaptiles.tileset import Tileset
+
+
+async def main(args):
+    tileset_path = args['<tileset>']
+    pghost, pgport, dbname, user, password = parse_pg_args(args)
+    layer = args.layer
+    columns = args.column
+    max_count = args['--max-count']
+    for c in columns:
+        if not re.match(r'^[a-z_][a-z0-9_]*$', c):
+            raise DocoptExit(f"Column '{c}' is invalid")
+    zooms = [int(v) for v in args['--zoom']]
+    if not zooms:
+        zooms = list(range(int(args['--minzoom']), int(args['--maxzoom']) + 1))
+    verbose = args['--verbose']
+
+    tileset = Tileset.parse(tileset_path)
+    conn = await asyncpg.connect(
+        database=dbname, host=pghost, port=pgport, user=user, password=password,
+    )
+    pg_warnings = PgWarnings(conn, delay_printing=True)
+    mvt = MvtGenerator(
+        tileset,
+        zoom=None, x=None, y=None,
+        layer_ids=[layer],
+        postgis_ver=await get_postgis_version(conn),
+    )
+
+    layer_def = tileset.layers_by_id[layer]
+    if layer_def.has_localized_names:
+        # Alter stored query to hide localized names
+        layer_def.definition['layer']['datasource']['query'] = \
+            layer_def.raw_query.format(name_languages='NULL as _hidden_names_')
+    raw_query = mvt.layer_to_query(layer_def, to_mvt_geometry=False)
+    query = mvt.substitute_sql(raw_query, 'CAST($1 as int)',
+                               mvt.bbox(0, 0, 0)).strip()
+    if len(columns) > 1 and not args.frequency:
+        raise DocoptExit(f"The 'toplength' and 'variance' methods require "
+                         f"a single column, but {len(columns)} was given")
+    if args.frequency:
+        method = "field frequency"
+        fields = ','.join(columns) if columns else '*'
+        query = f"""
+            SELECT {fields}, count(*) AS _count
+            FROM {query}
+            GROUP BY {fields}
+            ORDER BY {fields};
+            """.strip()
+        result_column = '_count'
+    elif args.toplength:
+        method = "longest field values"
+        query = f"""
+            SELECT DISTINCT {columns[0]}, length( {columns[0]} ) AS _length
+            FROM {query}
+            WHERE length( {columns[0]} ) > 0
+            ORDER BY length( {columns[0]} ) DESC NULLS LAST
+            LIMIT {max_count};
+            """.strip()
+        result_column = '_length'
+    elif args.variance:
+        method = "field value variance"
+        query = f"""
+            SELECT
+              'z' || $1                as zoom, 
+              COUNT( {columns[0]} )    as count,
+              MIN( {columns[0]} )      as min,
+              MAX( {columns[0]} )      as max,
+              AVG( {columns[0]} )      as avg,
+              STDDEV( {columns[0]} )   as stddev,
+              VARIANCE( {columns[0]} ) as variance
+            FROM {query};
+            """.strip()
+        result_column = None  # multiple columns
+    else:
+        raise DocoptExit("Unknown method used")
+
+    if verbose:
+        print(f"\n======= Querying layer {layer} (#{layer_def.index}) =======\n"
+              f"{query}")
+
+    if args.variance:
+        results = []
+    else:
+        results = defaultdict(dict)
+    for zoom in zooms:
+        try:
+            query_result = await conn.fetch(query, zoom)
+        except asyncpg.PostgresError as err:
+            print_query_error(f"ERROR in {layer} layer",
+                              err, pg_warnings, verbose, query)
+            return
+        for row in query_result:
+            if args.variance:
+                if row['count']:
+                    results.append(dict(row))
+            else:
+                key = tuple(row[v] for v in columns)
+                results[key][zoom] = row[result_column]
+        if pg_warnings.messages:
+            print(f"======= Layer {layer} has warnings at zoom {zoom} =======")
+            pg_warnings.print()
+
+    if results:
+        if args.variance:
+            values = results
+            headers = "keys"
+        else:
+            existing_zooms = set()
+            values = []
+            for key, zoom_dict in results.items():
+                vals = {v: fmt_val(key[i]) for i, v in enumerate(columns)}
+                for z, v in zoom_dict.items():
+                    vals[f"z{z}"] = v
+                    existing_zooms.add(z)
+                values.append(vals)
+            headers = {v: v for v in
+                       (columns + [f"z{z}" for z in sorted(existing_zooms)])}
+        print(f"======= Analyzing {method} in layer '{layer}' "
+              f"for [{', '.join(columns)}] =======")
+        print(tabulate(values, headers=headers))
+    else:
+        print(f"======= Analyzing {method} in layer '{layer}' "
+              f"for [{', '.join(columns)}] found no data =======")
+
+
+def fmt_val(val):
+    return '<null>' if val is None else '<blank>' if val == '' else val
+
+
+if __name__ == '__main__':
+    asyncio.run(main(docopt(__doc__, version=openmaptiles.__version__)))

--- a/bin/layer-stats
+++ b/bin/layer-stats
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Shows per-layer statistics in a database.
+Show per zoom statistics for some column (field) in a single layer.
 
 Usage:
   layer-stats frequency <tileset> <layer> <column>...
@@ -100,39 +100,36 @@ async def main(args):
         raise DocoptExit(f"The 'toplength' and 'variance' methods require "
                          f"a single column, but {len(columns)} was given")
     if args.frequency:
-        method = "field frequency"
-        fields = ','.join(columns) if columns else '*'
+        method = "value occurrence"
+        fields = ','.join(columns)
         query = f"""
-            SELECT {fields}, count(*) AS _count
-            FROM {query}
-            GROUP BY {fields}
-            ORDER BY {fields};
+SELECT {fields}, count(*) AS _result
+FROM {query}
+GROUP BY {fields}
+ORDER BY {fields};
             """.strip()
-        result_column = '_count'
     elif args.toplength:
         method = "longest field values"
         query = f"""
-            SELECT DISTINCT {columns[0]}, length( {columns[0]} ) AS _length
-            FROM {query}
-            WHERE length( {columns[0]} ) > 0
-            ORDER BY length( {columns[0]} ) DESC NULLS LAST
-            LIMIT {max_count};
+SELECT DISTINCT {columns[0]}, length( {columns[0]} ) AS _result
+FROM {query}
+WHERE length( {columns[0]} ) > 0
+ORDER BY length( {columns[0]} ) DESC NULLS LAST
+LIMIT {max_count};
             """.strip()
-        result_column = '_length'
     elif args.variance:
         method = "field value variance"
         query = f"""
-            SELECT
-              'z' || $1                as zoom, 
-              COUNT( {columns[0]} )    as count,
-              MIN( {columns[0]} )      as min,
-              MAX( {columns[0]} )      as max,
-              AVG( {columns[0]} )      as avg,
-              STDDEV( {columns[0]} )   as stddev,
-              VARIANCE( {columns[0]} ) as variance
-            FROM {query};
+SELECT
+  'z' || $1                as zoom,
+  COUNT( {columns[0]} )    as count,
+  MIN( {columns[0]} )      as min,
+  MAX( {columns[0]} )      as max,
+  AVG( {columns[0]} )      as avg,
+  STDDEV( {columns[0]} )   as stddev,
+  VARIANCE( {columns[0]} ) as variance
+FROM {query};
             """.strip()
-        result_column = None  # multiple columns
     else:
         raise DocoptExit("Unknown method used")
 
@@ -157,11 +154,13 @@ async def main(args):
                     results.append(dict(row))
             else:
                 key = tuple(row[v] for v in columns)
-                results[key][zoom] = row[result_column]
+                results[key][zoom] = row['_result']
         if pg_warnings.messages:
             print(f"======= Layer {layer} has warnings at zoom {zoom} =======")
             pg_warnings.print()
 
+    print(f"======= Analyzing {method} in layer '{layer}' "
+          f"for field{'s' if len(columns) > 1 else ''} [{', '.join(columns)}] =======")
     if results:
         if args.variance:
             values = results
@@ -177,12 +176,9 @@ async def main(args):
                 values.append(vals)
             headers = {v: v for v in
                        (columns + [f"z{z}" for z in sorted(existing_zooms)])}
-        print(f"======= Analyzing {method} in layer '{layer}' "
-              f"for [{', '.join(columns)}] =======")
         print(tabulate(values, headers=headers))
     else:
-        print(f"======= Analyzing {method} in layer '{layer}' "
-              f"for [{', '.join(columns)}] found no data =======")
+        print("No results were found")
 
 
 def fmt_val(val):

--- a/bin/profile-pg-func
+++ b/bin/profile-pg-func
@@ -52,7 +52,7 @@ from tabulate import tabulate
 from typing import List
 
 import openmaptiles
-from openmaptiles.pgutils import parse_pg_args, PgWarnings
+from openmaptiles.pgutils import parse_pg_args, PgWarnings, print_query_error
 from openmaptiles.utils import round_td, shorten_str
 
 
@@ -145,15 +145,8 @@ SELECT count(*) FROM (SELECT {stat.function} FROM generate_series(1, {calls})) c
                 took = dt.utcnow() - start
             except asyncpg.PostgresError as err:
                 took = dt.utcnow() - start
-                msg = f"####### ERROR running {stat.function} ({took:.2f}s) #######"
-                line = '#' * len(msg)
-                print(f"{line}\n{msg}\n{line}\n{err.__class__.__name__}: {err}")
-                if hasattr(err, "context") and err.context:
-                    print(f"context: {err.context}")
-                pg_warnings.print()
-                if not verbose:
-                    print(f'Failed query: {query}')
-                print(f"{line}\n")
+                print_query_error(f"ERROR running {stat.function} ({took:.2f}s)",
+                                  err, pg_warnings, verbose, query)
                 return
 
             stat.perf_delta.append(took)

--- a/openmaptiles/pgutils.py
+++ b/openmaptiles/pgutils.py
@@ -148,3 +148,19 @@ async def get_vector_layers(conn, mvt) -> List[dict]:
         ))
 
     return vector_layers
+
+
+def print_query_error(error_msg, err, pg_warnings, verbose, query, layer_sql=None):
+    msg = f"####### {error_msg} #######"
+    line = '#' * len(msg)
+    print(f"{line}\n{msg}\n{line}\n{err.__class__.__name__}: {err}")
+    if hasattr(err, "context") and err.context:
+        print(f"context: {err.context}")
+    pg_warnings.print()
+    if not verbose:
+        # Always print failed SQL if the mode is not verbose
+        query_msg = f"\n== FULL QUERY\n{query.strip()}"
+        if layer_sql:
+            query_msg += f"\n\n== MVT SQL\n{layer_sql}"
+        print(query_msg)
+    print(f"{line}\n")


### PR DESCRIPTION
The tool is modeled on the OpenMapTiles `qa/` tools. The tool shows some statistics for a given layer's field for each zoom. It currently supports 3 methods:

* `frequency` -- Shows how often each unique value occurs in a layer's column. If more than one column is given, shows unique combinations.
* `toplength` -- Shows the longest N values for a given layer's column.
* `variance` -- Shows a few statistical metrics for a column's numeric value.

This is a simple test script I used outside of the docker, and it could be adapted to run inside the docker as well. https://gist.github.com/nyurik/457102422adfb380ec9e8552d7656112

@TomPohys we can merge this and then add a new flag, e.g. `--markdown` to generate `.md` output.