### PR TITLE
Remove the double set of the header Access-Control-Allow-Origin.

### DIFF
--- a/openmaptiles/postserve.py
+++ b/openmaptiles/postserve.py
@@ -63,7 +63,6 @@ class GetTile(RequestHandledWithCors):
 
         self.set_header("Content-Type", "application/x-protobuf")
         self.set_header("Content-Disposition", "attachment")
-        self.set_header("Access-Control-Allow-Origin", "*")
         try:
             async with self.pool.acquire() as connection:
                 connection.add_log_listener(logger)


### PR DESCRIPTION
The header `Access-Control-Allow-Origin` is also set in the parent class `RequestHandledWithCors`.