### PR TITLE
Update generate-vectortiles docker image

### DIFF
--- a/docker/generate-vectortiles/Dockerfile
+++ b/docker/generate-vectortiles/Dockerfile
@@ -1,19 +1,16 @@
-FROM node:5
-MAINTAINER Lukas Martinelli <me@lukasmartinelli.ch>
+FROM node:8-slim
+LABEL maintainer="me@lukasmartinelli.ch"
 
 WORKDIR /usr/src/app
 RUN npm install -g \
-          tl@0.8.1 \
-          mapnik@3.5.13 \
-          mbtiles@0.8.2 \
-          tilelive@5.12.2 \
-          tilelive-tmsource@0.5.0 \
-          tilelive-vector@3.9.3 \
-          tilelive-bridge@2.3.1 \
-          tilelive-mapnik@0.6.18
+        mapnik@3.7.2 \
+        @mapbox/mbtiles@0.11.0 \
+        @mapbox/tilelive@6.1.0 \
+        tilelive-tmsource@0.8.2 \
+        --unsafe-perm
 
 VOLUME /tm2source /export
-ENV SOURCE_PROJECT_DIR=/tm2source EXPORT_DIR=/export TILELIVE_BIN=tl
+ENV SOURCE_PROJECT_DIR=/tm2source EXPORT_DIR=/export
 
 COPY . /usr/src/app/
 CMD ["/usr/src/app/export-local.sh"]

--- a/docker/generate-vectortiles/export-list.sh
+++ b/docker/generate-vectortiles/export-list.sh
@@ -16,7 +16,7 @@ function export_local_mbtiles() {
        exit 500
     fi
 
-    filter_deprecation tilelive-copy \
+    exec tilelive-copy \
         --scheme="list" \
         --list="$LIST_FILE" \
         --timeout="$TILE_TIMEOUT" \

--- a/docker/generate-vectortiles/export-local.sh
+++ b/docker/generate-vectortiles/export-local.sh
@@ -14,9 +14,9 @@ readonly TILE_TIMEOUT=${TILE_TIMEOUT:-1800000}
 readonly MBTILES_NAME=${MBTILES_NAME:-tiles.mbtiles}
 
 function export_local_mbtiles() {
-    echo "Generating tiles into $EXPORT_DIR/$MBTILES_NAME for zooms $MIN_ZOOM..$MAX_ZOOM inside ($BBOX) using $COPY_CONCURRENCY threads"
+    echo "Generating tiles into $EXPORT_DIR/$MBTILES_NAME for zooms $MIN_ZOOM..$MAX_ZOOM inside ($BBOX) using $COPY_CONCURRENCY concurrent I/O operations"
 
-    filter_deprecation tilelive-copy \
+    exec tilelive-copy \
         --scheme=pyramid \
         --bounds="$BBOX" \
         --timeout="$TILE_TIMEOUT" \

--- a/docker/generate-vectortiles/utils.sh
+++ b/docker/generate-vectortiles/utils.sh
@@ -40,37 +40,3 @@ function replace_db_connection() {
     sed -i "$replace_expr_4" "$DEST_PROJECT_FILE"
     sed -i "$replace_expr_5" "$DEST_PROJECT_FILE"
 }
-
-# Fix Mapnik output and errors
-#
-# Usage:
-#   filter_deprecation tilelive-copy ...
-#
-function filter_deprecation()(
-  set -e
-  if [[ -z "${FILTER_MAPNIK_OUTPUT:-}" ]]; then
-    # if FILTER_MAPNIK_OUTPUT is not set, execute as is, without any filtering
-    echo "Set FILTER_MAPNIK_OUTPUT=1 to hide deprecation warnings"
-    "$@"
-    return 0
-  fi
-
-  echo "Filtering deprecation warnings from the Mapnik's output."
-  (
-    # Swap stdin and stderr
-    "$@" 3>&2- 2>&1- 1>&3- | (
-      # Remove "is deprecated" error messages
-      sed -u "/is deprecated/d"
-  # Swap back stdin and stderr
-  )) 3>&2- 2>&1- 1>&3- | \
-  # Fix time precision
-  sed -u "s/s\] /000&/;s/\(\.[0-9][0-9][0-9]\)[0-9]*s\] /\1s] /" | \
-  # Redraw progress on the same line
-  while read line; do
-  if [[ "$line" == *left ]] ; then
-    echo -n "$line"
-  else
-    echo "$line"
-  fi
-done
-);


### PR DESCRIPTION
This will update the docker image to Mapnik 3.7.2 and Node 8. I also removed some unused libraries.

Benefits:
- Much smaller image
- Newer versions
- `FILTER_MAPNIK_OUTPUT` not needed anymore.

Note: 
Because of https://github.com/openmaptiles/openmaptiles/issues/517, I tried to use Mapnik 4.4.0 (and Node 12). I hoped that this bug is fixed since Mapnik 4.3.0 (see https://github.com/mapnik/node-mapnik/blob/master/CHANGELOG.md#430). Before updating to Mapnik 4.4.0 it looks like "tilelive-tmsource" needs to get updated first. But maybe this update is obsolet in case of https://github.com/openmaptiles/openmaptiles/issues/875.