### PR TITLE
generate-imposm3: preserve mapping order

### DIFF
--- a/bin/generate-imposm3
+++ b/bin/generate-imposm3
@@ -17,4 +17,4 @@ from openmaptiles.imposm import create_imposm3_mapping
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
     mapping = create_imposm3_mapping(args['<tileset>'])
-    print(yaml.safe_dump(mapping))
+    print(yaml.safe_dump(mapping, sort_keys=False))

--- a/tests/expected/imposm3.yaml
+++ b/tests/expected/imposm3.yaml
@@ -1,24 +1,3 @@
-generalized_tables: {}
-tables:
-  housenumber_point:
-    fields:
-    - name: osm_id
-      type: id
-    - name: geometry
-      type: geometry
-    - key: addr:housenumber
-      name: housenumber
-      type: string
-    - name: tags
-      type: hstore_tags
-    type: geometry
-    type_mappings:
-      points:
-        addr:housenumber:
-        - __any__
-      polygons:
-        addr:housenumber:
-        - __any__
 tags:
   include:
   - access
@@ -30,4 +9,25 @@ tags:
   - name:en
   - wikidata
   - wikipedia
+generalized_tables: {}
+tables:
+  housenumber_point:
+    type: geometry
+    fields:
+    - name: osm_id
+      type: id
+    - name: geometry
+      type: geometry
+    - name: housenumber
+      key: addr:housenumber
+      type: string
+    - name: tags
+      type: hstore_tags
+    type_mappings:
+      points:
+        addr:housenumber:
+        - __any__
+      polygons:
+        addr:housenumber:
+        - __any__
 


### PR DESCRIPTION
The script `generate-imposm3` reorders mapping keys in the output. This can be anoying as this order can be used to prioritize some keys, from [imposm's documentation](https://github.com/omniscale/imposm3/blob/master/docs/mapping.rst#mapping_key):

> Imposm will choose the first key of the table mapping if an OSM element has multiple tags that match. For example: mapping_key will use natural for an OSM element with landuse=forest and natural=wood tags, if natural comes before landuse in the table mapping. You need to define an explicit column if you need the value of a specific tag (e.g. {"type": "string", "name": "landuse", "key": "landuse"}).

### Example:

Using the following input:

`openmaptiles.yaml`

```yaml
tileset:
  layers:
    - layers/poi/poi.yaml
  name: OpenMapTiles
  version: 3.11.0
  id: openmaptiles
  description: "A tileset showcasing all layers in OpenMapTiles. https://openmaptiles.org"
  attribution: '<a href="https://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
  center: [-12.2168, 28.6135, 4]
  bounds: [-180.0,-85.0511,180.0,85.0511]
  maxzoom: 14
  minzoom: 0
  pixel_scale: 256
  languages:
    - fr # French, Latin
  defaults:
    srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
    datasource:
      srid: 900913
```

`layers/poi/mapping.yaml`

```yaml
def_poi_mapping: &poi_mapping
  craft:
    - restaurant
  amenity:
    - winery

def_poi_fields: &poi_fields
  - name: osm_id
    type: id

tables:
  test_poi_point:
    type: point
    fields: *poi_fields
    mapping: *poi_mapping

  test_poi_polygon:
    type: polygon
    fields: *poi_fields
    mapping: *poi_mapping
```

**Previous result:** (notice that `craft` and `amenity` are reversed)

```yaml
generalized_tables: {}
tables:
  test_poi_point:
    fields: &id001
    - name: osm_id
      type: id
    mapping: &id002
      amenity:
      - restaurant
      craft:
      - winery
    type: point
  test_poi_polygon:
    fields: *id001
    mapping: *id002
    type: polygon
tags:
  include:
  - int_name
  - loc_name
  - name
  - name:fr
  - wikidata
  - wikipedia
```

**With this PR:**

```yaml
tags:
  include:
  - int_name
  - loc_name
  - name
  - name:fr
  - wikidata
  - wikipedia
generalized_tables: {}
tables:
  test_poi_point:
    type: point
    fields: &id001
    - name: osm_id
      type: id
    mapping: &id002
      craft:
      - winery
      amenity:
      - restaurant
  test_poi_polygon:
    type: polygon
    fields: *id001
    mapping: *id002
```