### PR TITLE
mbtiles-tools fix broken --show-json param

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ layer:
   description: Buildings from OpenStreetMap
   buffer_size: 4
   datasource:
-    query: (SELECT geometry FROM layer_building(!bbox!, z(!scale_denominator!))) AS t
+    query: (SELECT geometry, render_height, class FROM layer_building(!bbox!, z(!scale_denominator!))) AS t
   fields:
     render_height: An approximated height from levels and height of building.
     class:

--- a/bin/mbtiles-tools
+++ b/bin/mbtiles-tools
@@ -12,11 +12,11 @@ Usage:
   mbtiles-tools meta-get <mbtiles-file> <metakey>
   mbtiles-tools meta-set <mbtiles-file> <metakey> [<newvalue>]
   mbtiles-tools meta-generate <mbtiles-file> <tileset>
-                [--reset] [--auto-minmax] [--show-ranges]
+                [--reset] [--auto-minmax] [--show-json] [--show-ranges]
                 [--pghost=<host>] [--pgport=<port>] [--dbname=<db>]
                 [--user=<user>] [--password=<password>]
   mbtiles-tools meta-copy <mbtiles-file> <target-mbtiles-file>
-                [--reset] [--auto-minmax] [--show-ranges]
+                [--reset] [--auto-minmax] [--show-json] [--show-ranges]
   mbtiles-tools tile <mbtiles-file> <tile_zxy> [--show-names] [--summary]
   mbtiles-tools --help
   mbtiles-tools --version
@@ -62,7 +62,7 @@ Options:
   -k --key=<hash>       Key of the tile (i.e. an MD5 hash). Could be multiple.
   -f --keyfile=<file>   A file with tile Keys, one per line.
   -o --output=<file>    Write a list of tiles to this file. Use '-' for stdout.
-  -j --show-json        For meta-all, print out the entire JSON field (compact-pretty-printed)
+  -j --show-json        Print out the entire JSON field (compact-pretty-printed) when showing metadata.
   -r --show-ranges      Show tile counts and ranges statistics for each zoom in mbtiles.
   -v --verbose          Print additional debugging information.
   --reset               For meta-generate and meta-copy, clear all existing metadata first.
@@ -100,23 +100,24 @@ def main():
     elif args['impute']:
         impute(args)
     elif args['meta-all']:
-        Metadata(args['<mbtiles-file>']).print_all(
-            show_json=args['--show-json'], show_ranges=args['--show-ranges'])
+        Metadata(args['<mbtiles-file>'], args['--show-json'],
+                 args['--show-ranges']).print_all()
     elif args['meta-get']:
         Metadata(args['<mbtiles-file>']).get_value(args['<metakey>'])
     elif args['meta-set']:
-        Metadata(args['<mbtiles-file>']).set_value(
-            args['<metakey>'], args['<newvalue>'])
+        Metadata(args['<mbtiles-file>']).set_value(args['<metakey>'],
+                                                   args['<newvalue>'])
     elif args['meta-generate']:
         pghost, pgport, dbname, user, password = parse_pg_args(args)
-        asyncio.run(Metadata(args['<mbtiles-file>']).generate(
-            args['<tileset>'], reset=args['--reset'],
-            auto_minmax=args['--auto-minmax'], show_ranges=args['--show-ranges'],
+        asyncio.run(Metadata(args['<mbtiles-file>'], args['--show-json'],
+                             args['--show-ranges']).generate(
+            args['<tileset>'], reset=args['--reset'], auto_minmax=args['--auto-minmax'],
             pghost=pghost, pgport=pgport, dbname=dbname, user=user, password=password))
     elif args['meta-copy']:
-        Metadata(args['<mbtiles-file>']).copy(
+        Metadata(args['<mbtiles-file>'], args['--show-json'],
+                 args['--show-ranges']).copy(
             args['<target-mbtiles-file>'], reset=args['--reset'],
-            auto_minmax=args['--auto-minmax'], show_ranges=args['--show-ranges'])
+            auto_minmax=args['--auto-minmax'])
     elif args['tile']:
         Metadata(args['<mbtiles-file>']).show_tile(
             *parse_zxy_param(args['<tile_zxy>']),


### PR DESCRIPTION
A minor reorg of mbtiles-tools to properly handle
`--show-json` option whenever printing json values.

unrelated - minor readme fix

closes #303