### PR TITLE
Use print_err in places that mix errors and output on stdout.

### DIFF
--- a/bin/generate-sql
+++ b/bin/generate-sql
@@ -18,6 +18,7 @@ from pathlib import Path
 from docopt import docopt
 import openmaptiles
 from openmaptiles.sql import collect_sql
+from openmaptiles.utils import print_err
 
 if __name__ == '__main__':
     args = docopt(__doc__, version=openmaptiles.__version__)
@@ -40,12 +41,16 @@ if __name__ == '__main__':
                 file.unlink()
                 deleted_files += 1
             else:
-                print(f"Unexpected file {file} is ignored")
+                print_err(f"Unexpected file {file} is ignored")
+
         if deleted_files:
-            print(f"Removed {deleted_files} existing files in dir {parallel_dir}")
+            print_err(f"Removed {deleted_files} existing files in dir {parallel_dir}")
 
         (path / 'run_first.sql').write_text(run_first)
         (path / 'run_last.sql').write_text(run_last)
         for file, sql in parallel_sql.items():
-            (parallel_dir / f'{file}.sql').write_text(sql)
-        print(f'Created {len(parallel_sql)} sql files for parallel execution at {path}')
+            (parallel_dir / f"{file}.sql").write_text(sql)
+
+        print_err(
+            f"Created {len(parallel_sql)} sql files for parallel execution at {path}"
+        )

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -7,6 +7,8 @@ import sys
 import yaml
 from deprecated import deprecated
 
+from .utils import print_err
+
 
 def tag_fields_to_sql(fields):
     """Converts a list of fields stored in the tags hstore into a list of SQL fields:
@@ -364,8 +366,8 @@ def parse_file(file: Path) -> dict:
         try:
             return yaml.full_load(stream)
         except yaml.YAMLError as e:
-            print(f'Could not parse {file}')
-            print(e)
+            print_err(f"Could not parse {file}")
+            print_err(e)
             sys.exit(1)
 
 


### PR DESCRIPTION
We use these scripts in CI and since most of the scripts push results to `stdout`, we redirect the result to a file. This works great, until there's an error.

When there's an error, a few of the scripts push the errors to `stdout` instead of `stderr`. This means it appears the commands succeeded when they actually failed.

This commit adjusts some `print` statements to use `print_err` to ensure these results go to `stderr`.