### PR TITLE
WIP: generate-vectortiles: node 12 supports, drop filter_deprecation

### DIFF
--- a/docker/generate-vectortiles/Dockerfile
+++ b/docker/generate-vectortiles/Dockerfile
@@ -1,16 +1,25 @@
-FROM node:5
+FROM node:12
 MAINTAINER Lukas Martinelli <me@lukasmartinelli.ch>
+
+# to resolve sqlite3 permission errors
+USER node
+RUN mkdir -p /home/node/.npm-global ; \
+    chown -R node:node /home/node/.npm-global
+ENV PATH=/home/node/.npm-global/bin:$PATH
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 WORKDIR /usr/src/app
 RUN npm install -g \
-          tl@0.8.1 \
-          mapnik@3.5.13 \
-          mbtiles@0.8.2 \
-          tilelive@5.12.2 \
-          tilelive-tmsource@0.5.0 \
-          tilelive-vector@3.9.3 \
-          tilelive-bridge@2.3.1 \
-          tilelive-mapnik@0.6.18
+          tl@0.10.2 \
+          mapnik@4.5.2 \
+          git+https://github.com/mapbox/node-mbtiles.git \
+          # bump progress-stream to 2.0.0
+          git+https://github.com/smellman/tilelive#debug2 \
+          # @mapbox/tilelive@6.1.0 \
+          git+https://github.com/smellman/tilelive-tmsource.git#dev-0.9.0b \
+          @mapbox/tilelive-vector@4.2.0 \
+          @mapbox/tilelive-bridge@3.2.1 \
+          git+https://github.com/smellman/tilelive-mapnik#dev-1.1.0
 
 VOLUME /tm2source /export
 ENV SOURCE_PROJECT_DIR=/tm2source EXPORT_DIR=/export TILELIVE_BIN=tl

--- a/docker/generate-vectortiles/export-local.sh
+++ b/docker/generate-vectortiles/export-local.sh
@@ -16,13 +16,14 @@ readonly MBTILES_NAME=${MBTILES_NAME:-tiles.mbtiles}
 function export_local_mbtiles() {
     echo "Generating tiles into $EXPORT_DIR/$MBTILES_NAME for zooms $MIN_ZOOM..$MAX_ZOOM inside ($BBOX) using $COPY_CONCURRENCY threads"
 
-    filter_deprecation tilelive-copy \
+    tilelive-copy \
         --scheme="$RENDER_SCHEME" \
         --bounds="$BBOX" \
         --timeout="$TILE_TIMEOUT" \
         --concurrency="$COPY_CONCURRENCY" \
         --minzoom="$MIN_ZOOM" \
         --maxzoom="$MAX_ZOOM" \
+        --retry=10 \
         "tmsource://$DEST_PROJECT_DIR" "mbtiles://$EXPORT_DIR/$MBTILES_NAME"
 }
 


### PR DESCRIPTION
In my case, only AMD Ryzen machine will fail in progress generate-tiles.
So I try to bump node 5 to node 12.

- bump all versions.
- mapnik to 4.5.2 from 3.x in all dependencies.
- dropped filter_deprecation because the function break with new tilelive copy.

But there are some problems...

- tl, tilelive-tmsource are no test code.
- tilelive-mapnik's test will fail so I need more research about it.

[tilelive ecosystems](https://github.com/mapbox/TileLive) is not active now.
so I recommend to fork into [OMT](https://github.com/openmaptiles) and maintain forks.