### PR TITLE
Stop parallel import-sql on error #300

### DIFF
--- a/bin/import-sql
+++ b/bin/import-sql
@@ -47,7 +47,7 @@ function import_all_sql_files() {
       # Run import-sql script in parallel, up to MAX_PARALLEL_PSQL processes at the same time
       : "${MAX_PARALLEL_PSQL:=5}"
       echo "Importing $(find "$dir/parallel" -name "*.sql" | wc -l) sql files from $dir/parallel/, up to $MAX_PARALLEL_PSQL files at the same time"
-      find "$dir/parallel" -name "*.sql" -print0 | xargs -0 -I{} -P "$MAX_PARALLEL_PSQL" "$0" "{}"
+      find "$dir/parallel" -name "*.sql" -print0 | xargs -0 -I{} -P "$MAX_PARALLEL_PSQL" sh -c "\"$0\" \"{}\" || exit 255"
       echo "Finished importing sql files matching '$dir/parallel/*.sql'"
 
       if [[ -f "$dir/run_last.sql" ]]; then


### PR DESCRIPTION
When import all SQL in parallel it does not stop on error.

Use xargs special 255 exit code to stop running new jobs. But the running jobs still continues to the end.