### PR TITLE
Use pg_roles view instead of pg_authid table

### DIFF
--- a/bin/refresh-views
+++ b/bin/refresh-views
@@ -73,7 +73,7 @@ WITH objects AS (
         JOIN pg_rewrite r ON r.oid=d.objid
         JOIN pg_class c2 ON c2.oid=r.ev_class AND c2.oid != c.oid
         JOIN pg_namespace n2 ON c2.relnamespace=n2.oid
-        JOIN pg_authid au ON au.oid=c2.relowner
+        JOIN pg_roles au ON au.oid=c2.relowner
     WHERE c.relkind IN ('r','m','v','t','f')
 )
 (


### PR DESCRIPTION
Some cloud providers don't allow to query table `pg_authid` due to security reasons (that's the case on CloudSQL and I think it's the same for AWS RDS).

Running `./bin/refresh-views` on a CloudSQL database results with the following error:
```
asyncpg.exceptions.InsufficientPrivilegeError: permission denied for table pg_authid
```

According to [PostgreSQL documentation](https://www.postgresql.org/docs/current/catalog-pg-authid.html):

> Since this catalog contains passwords, it must not be publicly readable. pg_roles is a publicly readable view on pg_authid that blanks out the password field.

This small change fixes the error. 