### PR TITLE
remove slash from name

### DIFF
--- a/sql/zzz_language.sql
+++ b/sql/zzz_language.sql
@@ -24,6 +24,7 @@ CREATE OR REPLACE FUNCTION remove_latin(text) RETURNS text AS $$
     END LOOP;
     result := regexp_replace(result, '(\([ -.]*\)|\[[ -.]*\])', '');
     result := regexp_replace(result, ' +\. *$', '');
+    result := replace(result, '/', '');
     result := trim(both ' -\n' from result);
     RETURN result;
   END;


### PR DESCRIPTION
Remove slashes from name e.g. for marine point Baltic sea

OSM name -> `Baltijas jūra / Baltijos jūra / Itämeri / Läänemeri / Morze Bałtyckie / Östersjön / Østersøen / Ostsee / Балтийское море` leads to in result of `get_nonlatin_name` to `/   /  /  /   /  /  /  / Балтийское море`

**before**
![Screenshot from 2020-10-14 13-48-37](https://user-images.githubusercontent.com/5182210/95979441-50138480-0e24-11eb-95b1-30b8e2bf940d.png)

**after**
![Screenshot from 2020-10-14 13-51-55](https://user-images.githubusercontent.com/5182210/95979571-7df8c900-0e24-11eb-8a00-de57be5bc6ce.png)


