### PR TITLE
Remove filter_deprecation function

### DIFF
--- a/docker/generate-vectortiles/export-list.sh
+++ b/docker/generate-vectortiles/export-list.sh
@@ -16,7 +16,7 @@ function export_local_mbtiles() {
        exit 500
     fi
 
-    filter_deprecation tilelive-copy \
+    exec tilelive-copy \
         --scheme="list" \
         --list="$LIST_FILE" \
         --timeout="$TILE_TIMEOUT" \

--- a/docker/generate-vectortiles/export-local.sh
+++ b/docker/generate-vectortiles/export-local.sh
@@ -16,7 +16,7 @@ readonly MBTILES_NAME=${MBTILES_NAME:-tiles.mbtiles}
 function export_local_mbtiles() {
     echo "Generating tiles into $EXPORT_DIR/$MBTILES_NAME for zooms $MIN_ZOOM..$MAX_ZOOM inside ($BBOX) using $COPY_CONCURRENCY concurrent I/O operations"
 
-    filter_deprecation tilelive-copy \
+    exec tilelive-copy \
         --scheme="$RENDER_SCHEME" \
         --bounds="$BBOX" \
         --timeout="$TILE_TIMEOUT" \

--- a/docker/generate-vectortiles/utils.sh
+++ b/docker/generate-vectortiles/utils.sh
@@ -40,37 +40,3 @@ function replace_db_connection() {
     sed -i "$replace_expr_4" "$DEST_PROJECT_FILE"
     sed -i "$replace_expr_5" "$DEST_PROJECT_FILE"
 }
-
-# Fix Mapnik output and errors
-#
-# Usage:
-#   filter_deprecation tilelive-copy ...
-#
-function filter_deprecation()(
-  set -e
-  if [[ -z "${FILTER_MAPNIK_OUTPUT:-}" ]]; then
-    # if FILTER_MAPNIK_OUTPUT is not set, execute as is, without any filtering
-    echo "Set FILTER_MAPNIK_OUTPUT=1 to hide deprecation warnings"
-    "$@"
-    return 0
-  fi
-
-  echo "Filtering deprecation warnings from the Mapnik's output."
-  (
-    # Swap stdin and stderr
-    "$@" 3>&2- 2>&1- 1>&3- | (
-      # Remove "is deprecated" error messages
-      sed -u "/is deprecated/d"
-  # Swap back stdin and stderr
-  )) 3>&2- 2>&1- 1>&3- | \
-  # Fix time precision
-  sed -u "s/s\] /000&/;s/\(\.[0-9][0-9][0-9]\)[0-9]*s\] /\1s] /" | \
-  # Redraw progress on the same line
-  while read line; do
-  if [[ "$line" == *left ]] ; then
-    echo -n "$line"
-  else
-    echo "$line"
-  fi
-done
-);


### PR DESCRIPTION
Based on https://github.com/openmaptiles/openmaptiles-tools/pull/298 was confirm that the `filter_deprecation` function is not needed anymore. 

Thanks @zstadler for implemented `filter_deprecation` function and it will be used if in the future will be necessary.