### PR TITLE
Make generate-vectortiles img build optional

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,24 +11,28 @@ jobs:
       - name: Checkout the changes
         uses: actions/checkout@v2
 
-      - name: main
+      - name: Tests
         run: |
           make test
 
-          pushd docker/postgis
-          docker build .
-          popd
-
-          pushd docker/generate-vectortiles
-          docker build .
-          popd
-
-          # Do not auto-build import-data and postgis-preload due to high download requirements
-
-      - name: Save build results
+      - name: Save test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: build-result
-          path: |
-            build
+          path: build
+
+      - name: Build postgis docker
+        run: |
+          pushd docker/postgis
+          docker build .
+          popd
+
+      - name: Build generate-vectortiles docker
+        continue-on-error: true
+        run: |
+          pushd docker/generate-vectortiles
+          docker build .
+          popd
+
+        # Do not auto-build import-data and postgis-preload due to high download requirements

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,10 +65,6 @@ jobs:
           make build-docker
           push_docker openmaptiles-tools
 
-          df -h .
-          make build-generate-vectortiles
-          push_docker generate-vectortiles
-
           # Github has a very low disk limit, get rid of some data
           df -h .
           sudo docker system prune --all --force
@@ -79,3 +75,10 @@ jobs:
           push_docker import-data
           push_docker postgis-preloaded
           df -h .
+
+          # The generate-vectortiles docker image often fails build, so leave it as last step
+          df -h .
+          sudo docker system prune --all --force
+          df -h .
+          make build-generate-vectortiles
+          push_docker generate-vectortiles


### PR DESCRIPTION
The mapnik build step currently fails due to unknown upstream changes, so this PR makes generate-vectortiles docker image optional, allowing us to continue development.

The generate-vectortiles image will be built last during on merge.