### PR TITLE
Clean any additional unit information

### DIFF
--- a/sql/CleanNumeric.sql
+++ b/sql/CleanNumeric.sql
@@ -11,7 +11,7 @@ __Returns:__ `numeric`
 ******************************************************************************/
 create or replace function CleanNumeric (i text) returns numeric as
 $body$
- SELECT substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)\s*$')::numeric;
+ SELECT substring(i from '^\s*([-+]?(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][-+]?\d+)?)[\s\w]*$')::numeric;
 $body$
 language sql
 strict immutable cost 20


### PR DESCRIPTION
some of the osm fields like the height unfortunately contain units (they should not be there - right)... by adding \w to the last part of the RegEx we can get rid of any kind of additional unit information (no matter if it's m, meter, ft, miles or any combination) - this will result in better 3D building rendering.

An example can be found here https://www.openstreetmap.org/edit#map=19/52.01690/8.52986 (roof of the church) that currently will not be rendered with the appropriate height - you can check it here: https://www.maptiler.com/maps/#streets/vector/18.2/8.529948/52.017556/0.00/60.0

And yes - I understand that "garbage in will result in garbage out" by default ;-) But sometimes this can be handled

here is a shot of my local result
![image](https://user-images.githubusercontent.com/8012359/131226749-9bf87aa5-3b8d-4564-8f95-f3f801ff7bc6.png)
