### PR TITLE
Moved layer-id from layer definition into tileset

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,10 +341,10 @@ generate-sql <tileset> --dir <outputdir>
 
 ### Generate Markdown Documentation
 
-Takes a tileset definition and generates Markdown documentation.
+Takes layer definition & layer id and generates Markdown documentation.
 
 ```
-generate-doc <tileset>
+generate-doc <layer-definition> <layer-id>
 ```
 
 ### Generate ETL (Extract-Transform-Load) graph
@@ -373,7 +373,8 @@ output fies:
 
 example:
 ```
-generate-sqlquery layers/landcover/landcover.yaml  14
+generate-sqlquery <layer-definition> <zoom-level> <layer-id>
+generate-sqlquery layers/landcover/landcover.yaml  14 landcover
 ```
 
 ### Import and Update OSM data

--- a/bin/generate-doc
+++ b/bin/generate-doc
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Usage:
-  generate-doc <layer-definition>
+  generate-doc <layer-definition> <layer-id>
   generate-doc --help
   generate-doc --version
 Options:
@@ -23,7 +23,7 @@ def generate_field_doc(field: Field):
 
 
 def main(args):
-    layer = Layer.parse(args['<layer-definition>'])
+    layer = Layer.parse(args['<layer-definition>'], args['<layer-id>'])
     fields_doc = '\n'.join((generate_field_doc(f) for f in layer.fields))
     print(f"{layer.description}\n\n## Fields\n\n{fields_doc}\n\n\n")
 

--- a/bin/generate-etlgraph
+++ b/bin/generate-etlgraph
@@ -4,7 +4,7 @@ Extract dependencies from the SQL and yaml layer files,
 and create dot/png/svg files for documentation.
 
 Usage:
-  generate-etlgraph <tileset-or-layer-file> <output-path> [<compare-path>] [--keep]
+  generate-etlgraph <tileset-or-layer-file> <output-path> [<layer-id>] [<compare-path>] [--keep]
                     [--format <format>]...
   generate-etlgraph --help
   generate-etlgraph --version
@@ -14,6 +14,7 @@ Usage:
   <compare-path>            If set, compares generated graphs with graphs that already
                             exist at this location, and exit with non-zero code
                             if they are not the same.
+  <layer-id>                If layer file is given a layer-id is required
 
 Options:
   -k --keep             If set, do not delete generated .dot file
@@ -31,6 +32,7 @@ from openmaptiles.diagram import EtlGraph
 def main(args):
     exit(EtlGraph(
         args['<tileset-or-layer-file>'],
+        args['<layer-id>'],
         args['<output-path>'],
         args['<compare-path>'],
         not args['--keep'],

--- a/bin/generate-mapping-graph
+++ b/bin/generate-mapping-graph
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Usage:
-  generate-mapping-graph <tileset-or-layer-file> <output-path> [<compare-path>] [--keep]
+  generate-mapping-graph <tileset-or-layer-file> <output-path> [<layer-id>] [<compare-path>] [--keep]
                          [--format <format>]...
   generate-mapping-graph --help
   generate-mapping-graph --version
@@ -11,6 +11,7 @@ Usage:
   <compare-path>            If set, compares generated graphs with graphs that already
                             exist at this location, and exit with non-zero code
                             if they are not the same.
+  <layer-id>                If layer file is given a layer-id is required
 
 Options:
   -k --keep             If set, do not delete generated .dot file
@@ -28,6 +29,7 @@ from openmaptiles.diagram import MappingGraph
 def main(args):
     exit(MappingGraph(
         args['<tileset-or-layer-file>'],
+        args['<layer-id>'],
         args['<output-path>'],
         args['<compare-path>'],
         not args['--keep'],

--- a/bin/generate-sqlquery
+++ b/bin/generate-sqlquery
@@ -2,7 +2,7 @@
 
 """
 Usage:
-  generate-sqlquery <layer-definition> <zoom-level>
+  generate-sqlquery <layer-definition> <zoom-level> <layer-id>
   generate-sqlquery --help
   generate-sqlquery --version
 Options:
@@ -21,7 +21,7 @@ def main(args):
     bbox = "ST_SetSRID(" \
            "'BOX3D(-20037508.34 -20037508.34, 20037508.34 20037508.34)'::box3d, 3857 )"
     zoom = args['<zoom-level>']
-    layer = Layer.parse(args['<layer-definition>'])
+    layer = Layer.parse(args['<layer-definition>'], args['<layer-id>'])
 
     sql = (layer.query
            .replace('!bbox!', bbox)

--- a/openmaptiles/diagram.py
+++ b/openmaptiles/diagram.py
@@ -8,9 +8,10 @@ from openmaptiles.tileset import process_layers, Layer
 
 
 class GraphGenerator:
-    def __init__(self, filename, output_dir, compare_dir, cleanup, extensions):
+    def __init__(self, filename, layerId, output_dir, compare_dir, cleanup, extensions):
         self.messages = []
         self.filename = Path(filename)
+        self.layerId = layerId
         self.output_dir = Path(output_dir)
         self.compare_dir = Path(compare_dir) if compare_dir else None
         self.cleanup = cleanup
@@ -44,7 +45,7 @@ class GraphGenerator:
             self.messages.append(f"Error validating {cmp_with}: {ex}")
 
     def run(self) -> int:
-        process_layers(self.filename, self.do_layer)
+        process_layers(self.filename, self.do_layer, self.layerId)
         if self.messages:
             print(f'Validation errors:')
             for msg in self.messages:

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -69,19 +69,23 @@ class Layer:
 
     def __init__(self,
                  layer_source: Union[str, Path, ParsedData],
+                 id: str,
                  tileset: 'Tileset' = None,
                  index: int = None):
         """
         :param layer_source: load layer from this source, e.g. a file
+        :param id: id of the layer
         :param tileset: parent tileset object (optional)
         :param index: layer's position index within the tileset
         """
         self.tileset = tileset
         self.index = index
+        self.id = id
 
         if isinstance(layer_source, ParsedData):
             self.filename = layer_source.path
             self.definition = layer_source.data
+            self.id = layer_source.id
         else:
             # if layer_source is a rooted path, the optional root_path will be ignored
             root_path = tileset.filename.parent if tileset else ''
@@ -156,10 +160,6 @@ class Layer:
         if self.tileset and self.has_localized_names:
             layer_fields += self.tileset.languages_as_fields()
         return layer_fields
-
-    @property
-    def id(self) -> str:
-        return self.definition['layer']['id']
 
     @property
     def description(self) -> str:
@@ -252,8 +252,8 @@ class Tileset:
         self.definition = self.definition['tileset']
         self.layers = []
         self.layers_by_id = {}
-        for index, layer_filename in enumerate(self.definition['layers']):
-            layer = Layer(layer_filename, self, index)
+        for index, layer_id in enumerate(self.definition['layers']):
+            layer = Layer(self.definition['layers'][layer_id], layer_id, self, index)
             if layer.id in self.layers_by_id:
                 raise ValueError(f"Layer '{layer.id}' is defined more than once")
             self.layers.append(layer)

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -261,8 +261,11 @@ class Tileset:
         self.definition = self.definition['tileset']
         self.layers = []
         self.layers_by_id = {}
+        isOldLayerListFormat = isinstance(self.definition['layers'], list)
         for index, layer_id in enumerate(self.definition['layers']):
-            layer = Layer(self.definition['layers'][layer_id], layer_id, self, index)
+            layer_definition = layer_id if isOldLayerListFormat else self.definition['layers'][layer_id]
+            id = None if isOldLayerListFormat else layer_id
+            layer = Layer(layer_definition, id, self, index)
             if layer.id in self.layers_by_id:
                 raise ValueError(f"Layer '{layer.id}' is defined more than once")
             self.layers.append(layer)

--- a/tests/python/test_sql.py
+++ b/tests/python/test_sql.py
@@ -66,25 +66,23 @@ $$ LANGUAGE SQL IMMUTABLE;
                 center="test_center",
                 defaults=dict(srs="test_srs", datasource=dict(srid="test_datasource")),
                 id="id1",
-                layers=[
-                    ParsedData(dict(
-                        layer=dict(
-                            buffer_size="test_buffer_size",
-                            datasource=dict(query="test_query"),
-                            id=v.id,
-                            fields={},
-                            requires=v.reqs
-                        ),
-                        schema=v.schema,
-                    ), Path(f'./{v.id}.yaml')) for v in layers
-                ],
+                layers=dict(
+                   (v.id, ParsedData(dict(
+                       layer=dict(
+                           buffer_size="test_buffer_size",
+                           datasource=dict(query="test_query"),
+                           fields={},
+                           requires=v.reqs
+                       ),
+                       schema=v.schema,
+                   ), Path(f'./{v.id}.yaml'))) for v in layers
+                ),
                 maxzoom="test_maxzoom",
                 minzoom="test_minzoom",
                 name="test_name",
                 pixel_scale="test_pixel_scale",
                 version="test_version",
             ))), Path("./tileset.yaml"))
-
         result = {
             k: "\n".join(
                 [query(vv) for vv in ([v] if isinstance(v, Case) else v)]

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -40,14 +40,14 @@ generate-sqltomvt "$TESTLAYERS/testmaptiles.yaml" --query --postgis-ver 2.5     
 generate-sqltomvt "$TESTLAYERS/testmaptiles.yaml" --query --postgis-ver 3.0       > "$BUILD/mvttile_query_v3.0.sql"
 generate-sqltomvt "$TESTLAYERS/testmaptiles.yaml" --query --test-geometry         > "$BUILD/mvttile_query_test_geom.sql"
 generate-sqltomvt "$TESTLAYERS/testmaptiles.yaml" --query --test-geometry --key   > "$BUILD/mvttile_query_test_geom_key.sql"
-generate-doc      "$TESTLAYERS/housenumber/housenumber.yaml"                      > "$BUILD/doc.md"
-generate-sqlquery "$TESTLAYERS/housenumber/housenumber.yaml" 14                   > "$BUILD/sqlquery.sql"
+generate-doc      "$TESTLAYERS/housenumber/housenumber.yaml" "housenumber"        > "$BUILD/doc.md"
+generate-sqlquery "$TESTLAYERS/housenumber/housenumber.yaml" 14 "housenumber"     > "$BUILD/sqlquery.sql"
 
 generate-etlgraph "$TESTLAYERS/testmaptiles.yaml" "$DEVDOC" --keep -f png -f svg
-generate-etlgraph "$TESTLAYERS/housenumber/housenumber.yaml" "$DEVDOC" --keep -f png -f svg
+generate-etlgraph "$TESTLAYERS/housenumber/housenumber.yaml" "$DEVDOC" "housenumber" --keep -f png -f svg
 
 generate-mapping-graph "$TESTLAYERS/testmaptiles.yaml" "$DEVDOC" --keep -f png -f svg
-generate-mapping-graph "$TESTLAYERS/housenumber/housenumber.yaml" "$DEVDOC/mapping_diagram" --keep -f png -f svg
+generate-mapping-graph "$TESTLAYERS/housenumber/housenumber.yaml" "$DEVDOC/mapping_diagram" "housenumber" --keep -f png -f svg
 
 echo "++++++++++++++++++++++++"
 echo "Testing download-osm"

--- a/tests/testlayers/enumfield/enumfield.yaml
+++ b/tests/testlayers/enumfield/enumfield.yaml
@@ -1,5 +1,4 @@
 layer:
-  id: enumfield
   description: |
     Test for converting enumfields
   buffer_size: 0

--- a/tests/testlayers/housenumber/housenumber.yaml
+++ b/tests/testlayers/housenumber/housenumber.yaml
@@ -1,5 +1,4 @@
 layer:
-  id: "housenumber"
   description: |
       Everything in OpenStreetMap which contains a `addr:housenumber` tag useful for labelling housenumbers on a map.
       This adds significant size to *z14*. For buildings the centroid of the building is used as housenumber.

--- a/tests/testlayers/mountain_peak/mountain_peak.yaml
+++ b/tests/testlayers/mountain_peak/mountain_peak.yaml
@@ -1,5 +1,4 @@
 layer:
-  id: "mountain_peak"
   description: |
       [Natural peaks](http://wiki.openstreetmap.org/wiki/Tag:natural%3Dpeak)
   buffer_size: 64

--- a/tests/testlayers/testmaptiles.yaml
+++ b/tests/testlayers/testmaptiles.yaml
@@ -1,8 +1,8 @@
 tileset:
   layers:
-    - housenumber/housenumber.yaml
-    - enumfield/enumfield.yaml
-    - mountain_peak/mountain_peak.yaml
+    housenumber: housenumber/housenumber.yaml
+    enumfield: enumfield/enumfield.yaml
+    mountain_peak: mountain_peak/mountain_peak.yaml
   name: TestMapTiles v1.0
   version: 1.1.1
   id: testmaptiles


### PR DESCRIPTION
With defining the Layer-Id in the tileset we can prevent that the same Layer-Id is used twice.

I implemented the fallback that if no id is found in the tileset or no id is passed over a bash script, it gets the id from the layer definition (old / current schema) and if there is also no id defined, it uses the layer filename as id.

Fix: https://github.com/openmaptiles/openmaptiles/issues/43
PR in `openmaptiles`: https://github.com/openmaptiles/openmaptiles/pull/1224

>We have internally agreed that OpenMapTiles should be more schema than layer catalog (since essentially it is always bound to a certain backend e.g. imposm3).
>What helps to solve the use case of alternative layers is that we will make the ids configurable in the tileset rather in tile definition #43  Then you can use the approach I described above and explicitly give them an ID.

_Originally posted by @lukasmartinelli in https://github.com/openmaptiles/openmaptiles/issues/28#issuecomment-262709200_


Old tileset:
```
tileset:
  layers:
    - layers/boundary/boundary.yaml
    - layers/highway/highway.yaml
    - layers/highway_name/highway_name.yaml
    - layers/building/building.yaml
    - layers/housenumber/housenumber.yaml
    - layers/place/place.yaml
```
New tileset:
```
tileset:
  layers:
    boundary: layers/boundary/boundary.yaml
    street: layers/highway/highway.yaml
    streetname: layers/highway_name/highway_name.yaml
    house: layers/building/building.yaml
    housenumber: layers/housenumber/housenumber.yaml
    place: layers/place/place.yaml
```