### PR TITLE
Revert to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux ;\
 
 
 # Build osmborder
-FROM python:3.10 as c-builder
+FROM python:3.9 as c-builder
 ARG OSMBORDER_REV=e3ae8f7a2dcdcd6dc80abab4679cb5edb7dc6fa5
 
 RUN set -eux ;\
@@ -60,7 +60,7 @@ RUN set -eux ;\
 
 
 # Primary image
-FROM python:3.10-slim
+FROM python:3.9-slim
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
 ARG PG_MAJOR=12


### PR DESCRIPTION
Tools in 6.0 used Python 3.8.  The 6.1 tried to upgrade to Python 3.10, but the [py-ascii-graph](https://github.com/kakwa/py-ascii-graph) is not compatible (used by the `test-perf` tool). Reverting to Python 3.9 should fix it for now.