### PR TITLE
Update lake centerlines

### DIFF
--- a/docker/import-data/Dockerfile
+++ b/docker/import-data/Dockerfile
@@ -8,7 +8,7 @@ RUN set -eux  ;\
     mkdir -p "$DIR"  ;\
     cd "$DIR"  ;\
     apk add --no-cache sqlite  ;\
-    wget --quiet https://naturalearth.s3.amazonaws.com/packages/natural_earth_vector.sqlite.zip ;\
+    wget --quiet https://dev.maptiler.download/geodata/omt/natural_earth_vector.sqlite.zip ;\
     unzip -oj natural_earth_vector.sqlite.zip  ;\
     ../clean-natural-earth.sh natural_earth_vector.sqlite  ;\
     rm ../clean-natural-earth.sh  ;\
@@ -28,7 +28,7 @@ RUN set -eux  ;\
     DIR=/downloads/lake_centerline  ;\
     mkdir -p "$DIR"  ;\
     cd "$DIR"  ;\
-    wget --quiet https://github.com/lukasmartinelli/osm-lakelines/releases/download/v0.9/lake_centerline.geojson
+    wget --quiet https://dev.maptiler.download/geodata/omt/lake_centerline.geojson
 
 
 FROM osgeo/gdal:alpine-normal-3.0.2

--- a/docker/import-data/import_data.sh
+++ b/docker/import-data/import_data.sh
@@ -71,7 +71,7 @@ if [ -z ${1+x} ] || [ "$1" = "lake-centerline" ]; then
   PGCLIENTENCODING=UTF8 ogr2ogr \
     -progress \
     -f Postgresql \
-    -s_srs EPSG:4326 \
+    -s_srs EPSG:3857 \
     -t_srs EPSG:3857 \
     "PG:$PGCONN" \
     -lco OVERWRITE=YES \


### PR DESCRIPTION
This PR does few things:

1. Lake centerlines were re-generated from latest planet (planet-211018.osm.pbf). There are now 38768 centerlines, instead of 14790. 
2. Centerlines in geojson are already in 3857 so there is no re-projection needed during import.
3. Links to lake_centerline.geojson and natural_earth_vector.sqlite.zip were updated to prevent a situation when data will be removed (https://github.com/openmaptiles/openmaptiles-tools/issues/366).
4. I kept `water-polygons-split-3857.zip` link as these data are regularly updated.