### PR TITLE
Remove `STRICT` statement

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -18,9 +18,9 @@ ARG PGSQL_GZIP_REPO=https://github.com/pramsey/pgsql-gzip.git
 ARG UTF8PROC_TAG=v2.5.0
 ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
-# osml10n - https://github.com/giggls/mapnik-german-l10n/releases
-ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9
-ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/giggls/mapnik-german-l10n.git
+# osml10n - https://github.com/openmaptiles/mapnik-german-l10n/releases
+ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9.1
+ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/openmaptiles/mapnik-german-l10n.git
 
 
 RUN set -eux  ;\

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -20,7 +20,6 @@ ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
 # osml10n - https://github.com/giggls/mapnik-german-l10n/releases
 ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9
-ARG MAPNIK_GERMAN_L10N_COMMIT=7e0a6aa13b5bf812370250a0af4c8776091bf278
 ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/giggls/mapnik-german-l10n.git
 
 
@@ -70,10 +69,8 @@ RUN set -eux  ;\
     ##
     ## osml10n extension (originally Mapnik German)
     cd /opt/  ;\
-    #git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG $MAPNIK_GERMAN_L10N_REPO  ;\
-    git clone --quiet $MAPNIK_GERMAN_L10N_REPO  ;\
+    git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG $MAPNIK_GERMAN_L10N_REPO  ;\
     cd mapnik-german-l10n  ;\
-    git checkout -b temporal_branch $MAPNIK_GERMAN_L10N_COMMIT ;\
     make  ;\
     make install  ;\
     rm -rf /opt/mapnik-german-l10n  ;\

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -20,6 +20,7 @@ ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
 # osml10n - https://github.com/giggls/mapnik-german-l10n/releases
 ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9
+ARG MAPNIK_GERMAN_L10N_COMMIT=7e0a6aa13b5bf812370250a0af4c8776091bf278
 ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/giggls/mapnik-german-l10n.git
 
 
@@ -69,8 +70,10 @@ RUN set -eux  ;\
     ##
     ## osml10n extension (originally Mapnik German)
     cd /opt/  ;\
-    git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG $MAPNIK_GERMAN_L10N_REPO  ;\
+    #git clone --quiet --depth 1 -b $MAPNIK_GERMAN_L10N_TAG $MAPNIK_GERMAN_L10N_REPO  ;\
+    git clone --quiet $MAPNIK_GERMAN_L10N_REPO  ;\
     cd mapnik-german-l10n  ;\
+    git checkout -b temporal_branch $MAPNIK_GERMAN_L10N_COMMIT ;\
     make  ;\
     make install  ;\
     rm -rf /opt/mapnik-german-l10n  ;\

--- a/docker/postgis/README.md
+++ b/docker/postgis/README.md
@@ -1,7 +1,7 @@
 # PostGIS + OSM-specific extensions Docker image
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-This images is based on PostgreSQL 9.6 and PostGIS 3.0 [Docker image](https://hub.docker.com/r/postgis/postgis/) and includes [osml10n extension](https://github.com/giggls/mapnik-german-l10n.git) - OSM-specific label manipulation support.
+This images is based on PostgreSQL 9.6 and PostGIS 3.0 [Docker image](https://hub.docker.com/r/postgis/postgis/) and includes [osml10n extension](https://github.com/openmaptiles/mapnik-german-l10n.git) - OSM-specific label manipulation support.
 
 ## Usage
 

--- a/docs/gcp_startup.sh
+++ b/docs/gcp_startup.sh
@@ -9,7 +9,7 @@ if (( $(id -u) != 0 )); then
 fi
 
 UTF8PROC_TAG=v2.5.0
-MAPNIK_GERMAN_L10N_TAG=v2.5.8
+MAPNIK_GERMAN_L10N_TAG=v2.5.9.1
 PGSQL_GZIP_TAG=v1.0.0
 
 CURL="curl --silent --show-error --location"
@@ -60,7 +60,7 @@ cd /opt
 rm -rf utf8proc
 
 echo "Installing mapnik-german-l10n"
-git clone --branch "$MAPNIK_GERMAN_L10N_TAG" --depth 1 https://github.com/giggls/mapnik-german-l10n.git
+git clone --branch "$MAPNIK_GERMAN_L10N_TAG" --depth 1 https://github.com/openmaptiles/mapnik-german-l10n.git
 cd mapnik-german-l10n
 git checkout -q
 make

--- a/sql/zzz_language.sql
+++ b/sql/zzz_language.sql
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION remove_latin(text) RETURNS text AS $$
 $$ LANGUAGE 'plpgsql' IMMUTABLE;
 
 -- See osml10n_is_latin
--- https://github.com/giggls/mapnik-german-l10n/blob/ea5da9cdfa6c931ae73eac747849140547ecd321/plpgsql/get_localized_name.sql#L19
+-- https://github.com/openmaptiles/mapnik-german-l10n/blob/ea5da9cdfa6c931ae73eac747849140547ecd321/plpgsql/get_localized_name.sql#L19
 CREATE or REPLACE FUNCTION omt_is_latin(text) RETURNS BOOLEAN AS $$
   DECLARE
     i integer;

--- a/sql/zzz_language.sql
+++ b/sql/zzz_language.sql
@@ -71,7 +71,7 @@ CREATE OR REPLACE FUNCTION get_latin_name(tags hstore, geometry geometry) RETURN
       NULLIF(tags->'int_name', ''),
       NULLIF(osml10n_get_name_without_brackets_from_tags(tags, 'en', geometry), '')
     );
-$$ LANGUAGE SQL IMMUTABLE STRICT;
+$$ LANGUAGE SQL IMMUTABLE;
 
 
 CREATE OR REPLACE FUNCTION get_nonlatin_name(tags hstore) RETURNS text AS $$
@@ -114,7 +114,7 @@ BEGIN
   END IF;
   RETURN hstore(tags_array);
 END;
-$$ STRICT
+$$
 LANGUAGE plpgsql IMMUTABLE;
 
 -- The wd_names table may also be created by the import-wikidata


### PR DESCRIPTION
Remove `STRICT` statement from `get_basic_names` and `get_latin_name` functions.

FIX https://github.com/openmaptiles/openmaptiles/issues/1319

Concurrently with PR https://github.com/openmaptiles/openmaptiles/pull/1320