### PR TITLE
Make `$PGPORT` work in `docker/postgis` image

### DIFF
--- a/docker/postgis/initdb-postgis.sh
+++ b/docker/postgis/initdb-postgis.sh
@@ -8,8 +8,8 @@ echo "  Loading OMT postgis extensions"
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
 for db in template_postgis "$POSTGRES_DB"; do
-echo "Loading extensions into $db"
-PGUSER="$POSTGRES_USER" psql --dbname="$db" <<-'EOSQL'
+  echo "Loading extensions into $db"
+  PGUSER="$POSTGRES_USER" "${psql[@]}" --dbname="$db" <<-'EOSQL'
     -- Cleanup. Ideally parent container shouldn't pre-install those.
     DROP EXTENSION IF EXISTS postgis_tiger_geocoder;
     DROP EXTENSION IF EXISTS postgis_topology;


### PR DESCRIPTION
Related to https://github.com/openmaptiles/openmaptiles/issues/1354

PostGIS initialization could not be completed if `$PGPORT` was not the default 5432.

For example, when using `PGPORT=54321`, the initialization is incomplete:

```
postgres_1                      | /usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
postgres_1                      | CREATE DATABASE
postgres_1                      | Loading PostGIS extensions into template_postgis
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | Loading PostGIS extensions into openmaptiles
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      |
postgres_1                      | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/20_omt_postgis.sh
postgres_1                      | ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
postgres_1                      |   Loading OMT postgis extensions
postgres_1                      | ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
postgres_1                      | Loading extensions into template_postgis
postgres_1                      | psql: connection to server at "postgres" (172.28.0.2), port 54321 failed: Connection refused
postgres_1                      |       Is the server running on that host and accepting TCP/IP connections?
```

where `20_omt_postgis.sh` is a copy of `docker/postgis/initdb-postgis.sh`

To make `20_omt_postgis.sh` work like `10_postgis.sh` does:

1. The execute bits were removed and the script is now sourced by the
  parent script `/usr/local/bin/docker-entrypoint.sh`.
2. `"${psql[@]}"` is used rather than `psql`.

The result is a complete initialization:

```
postgres_1                      | /usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
postgres_1                      | CREATE DATABASE
postgres_1                      | Loading PostGIS extensions into template_postgis
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | Loading PostGIS extensions into openmaptiles
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      |
postgres_1                      | /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/20_omt_postgis.sh
postgres_1                      | ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
postgres_1                      |   Loading OMT postgis extensions
postgres_1                      | ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
postgres_1                      | Loading extensions into template_postgis
postgres_1                      | DROP EXTENSION
postgres_1                      | DROP EXTENSION
postgres_1                      | NOTICE:  extension "postgis" already exists, skipping
postgres_1                      | CREATE EXTENSION
postgres_1                      | NOTICE:  extension "fuzzystrmatch" already exists, skipping
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | Loading extensions into openmaptiles
postgres_1                      | DROP EXTENSION
postgres_1                      | DROP EXTENSION
postgres_1                      | NOTICE:  extension "postgis" already exists, skipping
postgres_1                      | CREATE EXTENSION
postgres_1                      | NOTICE:  extension "fuzzystrmatch" already exists, skipping
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
postgres_1                      | CREATE EXTENSION
```