### PR TITLE
Upgrade to PostgreSQL 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -eux ;\
     go get github.com/tools/godep ;\
     mkdir /build-bin ;\
     \
-    /bin/bash -c 'echo ""; echo ""; echo "##### Build imposm3 -- https://github.com/osm2vectortiles/imposm3"' >&2 ;\
+    /bin/bash -c 'echo ""; echo ""; echo "##### Build imposm3 -- $IMPOSM_REPO in version $IMPOSM_VERSION"' >&2 ;\
     #
     # get and build specific version of imposm
     git clone --quiet --depth 1 $IMPOSM_REPO -b $IMPOSM_VERSION \
@@ -63,7 +63,7 @@ RUN set -eux ;\
 FROM python:3.9-slim
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
-ARG PG_MAJOR=12
+ARG PG_MAJOR=14
 ARG TOOLS_DIR=/usr/src/app
 
 WORKDIR ${TOOLS_DIR}
@@ -115,7 +115,7 @@ RUN set -eux ;\
         libprotobuf-dev \
         ;\
     # generate-tiles
-    curl -sL https://deb.nodesource.com/setup_12.x | bash -  ;\
+    curl -sL https://deb.nodesource.com/setup_14.x | bash -  ;\
     DEBIAN_FRONTEND=noninteractive apt-get update  ;\
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
         nodejs build-essential ;\
@@ -123,7 +123,7 @@ RUN set -eux ;\
     npm config set unsafe-perm true  ;\
     npm install -g \
       @mapbox/mbtiles@0.12.1 \
-      @mapbox/tilelive@6.1.0 \
+      @mapbox/tilelive@6.1.1 \
       tilelive-pgquery@1.2.0 ;\
     \
     /bin/bash -c 'echo ""; echo ""; echo "##### Cleaning up"' >&2 ;\

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -2,13 +2,13 @@
 # the postgis base image has outdated ogr2ogr (gdal-bin package)
 # does not support PG12 yet, which means postgis-preloaded cannot be built easily.
 # Once it is updated, or there is a different way to build it, we can upgrade to 12.
-ARG BASE_POSTGIS_VER=9.6-3.1
+ARG BASE_POSTGIS_VER=14-3.2
 FROM postgis/postgis:$BASE_POSTGIS_VER
 
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
 # https://github.com/libgeos/geos/releases
-ARG GEOS_VER=3.9.1
+#ARG GEOS_VER=3.9.3
 
 # https://github.com/pramsey/pgsql-gzip/releases
 ARG PGSQL_GZIP_TAG=v1.0.0
@@ -40,15 +40,15 @@ RUN set -eux  ;\
         libgdal-dev \
     ;\
     ## Install specific GEOS version
-    cd /opt/  ;\
-    curl -o /opt/geos.tar.bz2 http://download.osgeo.org/geos/geos-${GEOS_VER}.tar.bz2  ;\
-    mkdir /opt/geos  ;\
-    tar xf /opt/geos.tar.bz2 -C /opt/geos --strip-components=1  ;\
-    cd /opt/geos/  ;\
-    ./configure  ;\
-    make -j  ;\
-    make install  ;\
-    rm -rf /opt/geos*  ;\
+    #cd /opt/  ;\
+    #curl -o /opt/geos.tar.bz2 http://download.osgeo.org/geos/geos-${GEOS_VER}.tar.bz2  ;\
+    #mkdir /opt/geos  ;\
+    #tar xf /opt/geos.tar.bz2 -C /opt/geos --strip-components=1  ;\
+    #cd /opt/geos/  ;\
+    #./configure  ;\
+    #make -j  ;\
+    #make install  ;\
+    #rm -rf /opt/geos*  ;\
     ##
     ## gzip extension
     cd /opt/  ;\

--- a/docker/postgis/README.md
+++ b/docker/postgis/README.md
@@ -1,7 +1,7 @@
 # PostGIS + OSM-specific extensions Docker image
-[![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
+[![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-This images is based on PostgreSQL 9.6 and PostGIS 3.0 [Docker image](https://hub.docker.com/r/postgis/postgis/) and includes [osml10n extension](https://github.com/openmaptiles/mapnik-german-l10n.git) - OSM-specific label manipulation support.
+This images is based on PostgreSQL 14 and PostGIS 3.2 [Docker image](https://hub.docker.com/r/postgis/postgis/) and includes [osml10n extension](https://github.com/openmaptiles/mapnik-german-l10n.git) - OSM-specific label manipulation support.
 
 ## Usage
 

--- a/docker/postgis/README.md
+++ b/docker/postgis/README.md
@@ -1,5 +1,5 @@
 # PostGIS + OSM-specific extensions Docker image
-[![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
+[![Docker Automated build](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
 This images is based on PostgreSQL 14 and PostGIS 3.2 [Docker image](https://hub.docker.com/r/postgis/postgis/) and includes [osml10n extension](https://github.com/openmaptiles/mapnik-german-l10n.git) - OSM-specific label manipulation support.
 

--- a/docker/postgis/initdb-postgis.sh
+++ b/docker/postgis/initdb-postgis.sh
@@ -3,6 +3,14 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+# Tune-up performance for `make import-sql`
+echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+echo "  Pre-configuring Postgres 14 system"
+echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+PGUSER="$POSTGRES_USER" "${psql[@]}" --dbname="$POSTGRES_DB" <<-'EOSQL'
+    ALTER SYSTEM SET jit = 'off';
+EOSQL
+
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 echo "  Loading OMT postgis extensions"
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
This PR is upgrading PostgreSQL from 9.6 to 14.

GEOS 3.9.0 is used in Debian-bullseye image for building [postgis:14-3.2](https://github.com/postgis/docker-postgis/blob/master/14-3.2/Dockerfile#L1). I kept the code for the eventual manual update of GEOS.

There is also tune-up PostgreSQL to turn off `jit` which prolongs the `import-sql` step in OpenMapTiles.