### PR TITLE
Update to Natural Earth v5.1.2

### DIFF
--- a/docker/import-data/Dockerfile
+++ b/docker/import-data/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux  ;\
     wget --quiet https://dev.maptiler.download/geodata/omt/lake_centerline.geojson
 
 
-FROM osgeo/gdal:alpine-normal-3.4.1
+FROM osgeo/gdal:alpine-normal-3.5.1
 LABEL maintainer="Yuri Astrakhan <YuriAstrakhan@gmail.com>"
 
 ENV DATA_DIR=/import

--- a/docker/import-data/Dockerfile
+++ b/docker/import-data/Dockerfile
@@ -23,7 +23,7 @@ RUN set -eux  ;\
     unzip -oj water-polygons-split-3857.zip  ;\
     rm water-polygons-split-3857.zip
 
-# Download lake centerlines from https://github.com/lukasmartinelli/osm-lakelines
+# Download lake centerlines from https://dev.maptiler.download/geodata/omt/lake_centerline.geojson
 RUN set -eux  ;\
     DIR=/downloads/lake_centerline  ;\
     mkdir -p "$DIR"  ;\

--- a/docker/import-data/Dockerfile
+++ b/docker/import-data/Dockerfile
@@ -8,11 +8,11 @@ RUN set -eux  ;\
     mkdir -p "$DIR"  ;\
     cd "$DIR"  ;\
     apk add --no-cache sqlite  ;\
-    wget --quiet https://dev.maptiler.download/geodata/omt/natural_earth_vector.sqlite.zip ;\
-    unzip -oj natural_earth_vector.sqlite.zip  ;\
+    wget --quiet https://dev.maptiler.download/geodata/omt/natural_earth_vector.sqlite_v5.1.2.zip ;\
+    unzip -oj natural_earth_vector.sqlite_v5.1.2.zip  ;\
     ../clean-natural-earth.sh natural_earth_vector.sqlite  ;\
     rm ../clean-natural-earth.sh  ;\
-    rm natural_earth_vector.sqlite.zip
+    rm natural_earth_vector.sqlite_v5.1.2.zip
 
 # Download water polygons data from http://osmdata.openstreetmap.de
 RUN set -eux  ;\

--- a/docker/import-data/README.md
+++ b/docker/import-data/README.md
@@ -6,7 +6,7 @@ This is a Docker image containing several datasets used in OpenMapTiles project.
 Centered linestrings for labelling OpenStreetMap lakes from the [osm-lakelines](https://github.com/lukasmartinelli/osm-lakelines) repo.
 
 ### Natural Earth
-A subset of [NaturalEarth](http://www.naturalearthdata.com/) version [4.1](https://github.com/nvkelso/natural-earth-vector/releases/tag/v4.1.0).
+A subset of [NaturalEarth](http://www.naturalearthdata.com/) version [5.1.2](https://github.com/nvkelso/natural-earth-vector/releases/tag/v5.1.2).
 
 ### Water polygons
 Water polygons from [OpenStreetMapData](http://osmdata.openstreetmap.de/).

--- a/docker/import-data/README.md
+++ b/docker/import-data/README.md
@@ -3,7 +3,7 @@
 This is a Docker image containing several datasets used in OpenMapTiles project. Prepared data can be imported into PostgreSQL using ogr2ogr utility.
 
 ### Lakelines
-Centered linestrings for labelling OpenStreetMap lakes from the [osm-lakelines](https://github.com/lukasmartinelli/osm-lakelines) repo.
+Centered linestrings for labelling OpenStreetMap lakes from the [osm-lakelines](https://dev.maptiler.download/geodata/omt/lake_centerline.geojson) repo.
 
 ### Natural Earth
 A subset of [NaturalEarth](http://www.naturalearthdata.com/) version [5.1.2](https://github.com/nvkelso/natural-earth-vector/releases/tag/v5.1.2).

--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -26,9 +26,7 @@ function drop_table() {
 echo "Cleaning up $NATURAL_EARTH_DB - removing all unneeded tables. Initial size $(du -h "$NATURAL_EARTH_DB" | cut -f1)"
 
 #
-# TODO: this list needs to be cleaned up, and maybe remove a few more tables
-# Previous version listed all tables to be dropped, so this list was created by listing
-# all available tables and removing the dropped ones
+# Keep selected tables before import to the PostgreSQL database.
 #
 count=0
 for tbl in $(echo \

--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -44,9 +44,7 @@ for tbl in $(echo \
     "'ne_10m_lakes'," \
     "'ne_10m_ocean'," \
     "'ne_10m_populated_places'," \
-    "'ne_10m_rivers_lake_centerlines'," \
     "'ne_50m_admin_0_boundary_lines_land'," \
-    "'ne_50m_admin_1_states_provinces_lines'," \
     "'ne_50m_antarctic_ice_shelves_polys'," \
     "'ne_50m_glaciated_areas'," \
     "'ne_50m_lakes'," \


### PR DESCRIPTION
Update from Natural Earth 4.1 to Natural Earth 5.1.2.

This update has to be coordinated with OMT where are some changes.

Solves https://github.com/openmaptiles/openmaptiles-tools/issues/411 and https://github.com/openmaptiles/openmaptiles/issues/1379