### PR TITLE
Add style-tools binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,7 @@ RUN set -eux ;\
     npm install -g \
       @mapbox/mbtiles@0.12.1 \
       @mapbox/tilelive@6.1.1 \
+      @beyondtracks/spritezero-cli@2.3.1 \
       tilelive-pgquery@1.2.0 ;\
     \
     /bin/bash -c 'echo ""; echo ""; echo "##### Cleaning up"' >&2 ;\

--- a/bin/style-tools
+++ b/bin/style-tools
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""
+Usage:
+  style-tools split <tileset> <style>
+  style-tools merge <tileset> <style> <style_header>
+  style-tools recompose <tileset> <style> <style_header>
+  style-tools --help
+  style-tools --version
+
+Actions:
+  split           Break down style.json into separate jsons per yaml layer.
+  merge           Combine separate jsons into style.json.
+
+Options:
+  --help              Show this screen.
+  --version           Show version.
+"""
+from pathlib import Path
+from docopt import docopt
+import openmaptiles
+from openmaptiles.utils import print_err
+from openmaptiles.styleutils import merge, split
+
+if __name__ == '__main__':
+    args = docopt(__doc__, version=openmaptiles.__version__)
+    tileset = args['<tileset>']
+    tileset_fp = Path(tileset)
+    style = args['<style>']
+    style_fp = Path(style)
+    if args['split']:
+        split(tileset_fp, style_fp)
+    elif args['merge']:
+        style_header = args['<style_header>']
+        style_header_fp = Path(style_header)
+        merge(tileset_fp, style_fp, style_header_fp)
+    elif args['recompose']:
+        style_header = args['<style_header>']
+        style_header_fp = Path(style_header)
+        merge(tileset_fp, style_fp, style_header_fp)
+        split(tileset_fp, style_fp)

--- a/bin/style-tools
+++ b/bin/style-tools
@@ -20,10 +20,10 @@ from docopt import docopt
 import openmaptiles
 from openmaptiles.styleutils import merge, split
 
-if __name__ == '__main__':
+
+def main():
     args = docopt(__doc__, version=openmaptiles.__version__)
-    tileset = args['<tileset>']
-    tileset_fp = Path(tileset)
+    tileset_fp = Path(args['<tileset>'])
     style = args['<style>']
     style_fp = Path(style)
     if args['split']:
@@ -37,3 +37,7 @@ if __name__ == '__main__':
         style_header_fp = Path(style_header)
         merge(tileset_fp, style_fp, style_header_fp)
         split(tileset_fp, style_fp)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/style-tools
+++ b/bin/style-tools
@@ -18,7 +18,6 @@ Options:
 from pathlib import Path
 from docopt import docopt
 import openmaptiles
-from openmaptiles.utils import print_err
 from openmaptiles.styleutils import merge, split
 
 if __name__ == '__main__':

--- a/openmaptiles/styleutils.py
+++ b/openmaptiles/styleutils.py
@@ -1,4 +1,3 @@
-import yaml
 import json
 from pathlib import Path
 from openmaptiles.tileset import Tileset
@@ -25,8 +24,8 @@ def add_order(lyrs: list) -> list:
     return lyrs
 
 
-def get_order(l: dict) -> int:
-    return int(l.get('order'))
+def get_order(layer: dict) -> int:
+    return int(layer.get('order'))
 
 
 def split(tileset_fp: Path, style_fp: Path):

--- a/openmaptiles/styleutils.py
+++ b/openmaptiles/styleutils.py
@@ -9,7 +9,7 @@ def fp_to_dict(fp: Path) -> dict:
 
 def get_ts_lyr_style_json_fp(yaml_fp: str) -> Path:
     yaml_path = yaml_fp.filename
-    json_name = Path(yaml_path.name).with_suffix('.json')
+    json_name = Path(yaml_path.name).with_name('defaultstyle.json')
     ts_lyr_dir = yaml_path.parent
 
     return ts_lyr_dir.joinpath(json_name)

--- a/openmaptiles/styleutils.py
+++ b/openmaptiles/styleutils.py
@@ -9,7 +9,7 @@ def fp_to_dict(fp: Path) -> dict:
 
 def get_ts_lyr_style_json_fp(yaml_fp: str) -> Path:
     yaml_path = yaml_fp.filename
-    json_name = Path(yaml_path.name).with_name('defaultstyle.json')
+    json_name = Path(yaml_path.name).with_name('style.json')
     ts_lyr_dir = yaml_path.parent
 
     return ts_lyr_dir.joinpath(json_name)

--- a/openmaptiles/styleutils.py
+++ b/openmaptiles/styleutils.py
@@ -1,0 +1,87 @@
+import yaml
+import json
+from pathlib import Path
+from openmaptiles.tileset import Tileset
+
+
+def fp_to_dict(fp: str) -> dict:
+    with open(fp, 'r') as f:
+        d = json.load(f)
+    return d
+
+
+def get_ts_lyr_style_json_fp(yaml_fp: str) -> Path:
+    yaml_path = yaml_fp.filename
+    json_name = Path(yaml_path.name).with_suffix('.json')
+    ts_lyr_dir = yaml_path.parent
+
+    return ts_lyr_dir.joinpath(json_name)
+
+
+def add_order(lyrs: list) -> list:
+    for i in range(0, len(lyrs)):
+        lyr = lyrs[i]
+        lyr['order'] = i
+    return lyrs
+
+
+def get_order(l: dict) -> int:
+    return int(l.get('order'))
+
+
+def split(tileset_fp: Path, style_fp: Path):
+    tileset = Tileset.parse(tileset_fp)
+    tileset_lyrs = tileset.layers
+
+    # Add order to each style layer (e.g. backgroud - 0, labels - 196)
+    style = fp_to_dict(style_fp)
+    style_lyrs_w_order = add_order(style.get('layers'))
+
+    # ts_lyr is a layer in tileset.yaml (e.g. landuse, landcover, water, waterway...)
+    for ts_lyr in tileset_lyrs:
+        ts_lyr_style_json_fp = get_ts_lyr_style_json_fp(ts_lyr)
+        ts_lyr_style_lyrs = list()
+        for style_lyr in style_lyrs_w_order:
+            source_layer = style_lyr.get('source-layer')
+            if source_layer == ts_lyr.filename.stem:
+                ts_lyr_style_lyrs.append(style_lyr)
+        out_dict = {'layers': ts_lyr_style_lyrs}
+
+        # write style layers with order to json for specific tileset layer
+        with open(ts_lyr_style_json_fp, 'w') as fout:
+            json.dump(out_dict, fout, indent=2)
+
+
+def merge(tileset_fp: Path, style_fp: Path, style_header_fp: Path):
+    tileset = Tileset.parse(tileset_fp)
+    tileset_lyrs = tileset.layers
+    # Load style header file
+    style = fp_to_dict(style_header_fp)
+
+    style_lyrs = list()
+    # For each tileset layer read its style.json and append its layers to style_lyrs
+    for ts_lyr in tileset_lyrs:
+        ts_lyr_style_json_fp = get_ts_lyr_style_json_fp(ts_lyr)
+        with open(ts_lyr_style_json_fp, 'r') as f:
+            in_dict = json.load(f)
+        ts_lyr_style_lyrs = in_dict.get('layers')
+        for layer_style_layer in ts_lyr_style_lyrs:
+            if layer_style_layer.get('order') is None:
+                raise ValueError(f'Style layer {layer_style_layer.get("id")} in {ts_lyr_style_json_fp} has not '
+                                 f'a defined order.')
+            else:
+                style_lyrs.append(layer_style_layer)
+
+    # sort style_lyrs by order, let sort take care of duplicates
+    style_lyrs.sort(key=get_order)
+    # create a new list with original background layer
+    new_style_lyrs = style.get('layers')[:1]
+    # append sorted layers to new_style_lyrs
+    for style_lyr in style_lyrs:
+        # remove order kv
+        style_lyr.pop('order')
+        new_style_lyrs.append(style_lyr)
+    style['layers'] = new_style_lyrs
+    # save to temp file
+    with open(style_fp, 'w') as fout:
+        json.dump(style, fout, indent=2)

--- a/openmaptiles/styleutils.py
+++ b/openmaptiles/styleutils.py
@@ -4,7 +4,7 @@ from openmaptiles.tileset import Tileset
 
 
 def fp_to_dict(fp: Path) -> dict:
-    return json.loads(fp.read_text(encoding="utf-8"))
+    return json.loads(fp.read_text(encoding='utf-8'))
 
 
 def get_ts_lyr_style_json_fp(yaml_fp: str) -> Path:
@@ -24,7 +24,7 @@ def add_order(lyrs: list) -> list:
 def get_order(layer: dict) -> int:
     order = layer.get('order')
     if order is None:
-        raise ValueError(f"Missing order value in layer {layer.get('id')}")
+        raise ValueError(f'Missing order value in layer {layer.get("id")}')
     return int(order)
 
 
@@ -36,7 +36,7 @@ def split(tileset_fp: Path, style_fp: Path):
     style = fp_to_dict(style_fp)
     lyrs = style.get('layers')
     if not lyrs:
-        raise ValueError(f"No layers in {style_fp}.")
+        raise ValueError(f'No layers in {style_fp}.')
     style_lyrs_w_order = add_order(lyrs)
 
     # ts_lyr is a layer in tileset.yaml (e.g. landuse, landcover, water, waterway...)


### PR DESCRIPTION
This PR adds utility for handling style. Related to this PR in OMT: https://github.com/openmaptiles/openmaptiles/pull/1420

- It adds `spritezero` to generate sprite files from svg icons.
- It adds `style-tools` binary and `styleutils.py`. 

`style-tools split` to split `style.json` into style snippet `layer_name.json`, one per layer. Style snippets also keep the style layers `order` from the original style.json
`style-tools merge` to merge all style snippets into a new `style.json` with layers ordered based on `order` value.