### PR TITLE
Enable HTTP_PROXY Env Var for aiohttp Client

### DIFF
--- a/bin/download-osm
+++ b/bin/download-osm
@@ -658,7 +658,7 @@ async def main_async(args):
 
     urls, md5, repl_url = None, None, None
     exit_code = 0
-    async with aiohttp.ClientSession(trust_env=True,  headers={'User-Agent': USER_AGENT}) as session:
+    async with aiohttp.ClientSession(trust_env=True, headers={'User-Agent': USER_AGENT}) as session:
         force_latest = args['--force-latest']
         no_cache = args['--no-cache']
         if args.list:

--- a/bin/download-osm
+++ b/bin/download-osm
@@ -658,7 +658,7 @@ async def main_async(args):
 
     urls, md5, repl_url = None, None, None
     exit_code = 0
-    async with aiohttp.ClientSession(headers={'User-Agent': USER_AGENT}) as session:
+    async with aiohttp.ClientSession(trust_env=True, headers={'User-Agent': USER_AGENT}) as session:
         force_latest = args['--force-latest']
         no_cache = args['--no-cache']
         if args.list:

--- a/bin/download-osm
+++ b/bin/download-osm
@@ -658,7 +658,7 @@ async def main_async(args):
 
     urls, md5, repl_url = None, None, None
     exit_code = 0
-    async with aiohttp.ClientSession(trust_env=True, headers={'User-Agent': USER_AGENT}) as session:
+    async with aiohttp.ClientSession(trust_env=True,  headers={'User-Agent': USER_AGENT}) as session:
         force_latest = args['--force-latest']
         no_cache = args['--no-cache']
         if args.list:


### PR DESCRIPTION
With this tiny change ProxyEnv-Variables like `HTTP_PROXY` and `HTTPS_PROXY` injected via docker or shell work with aiohttp.

closes #419 