### PR TITLE
Add missing boundary data to OpenMapTiles

### DIFF
--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -34,6 +34,7 @@ for tbl in $(echo \
   "WHERE type='table' AND name like 'ne%' and name not in (" \
     "'ne_10m_admin_0_boundary_lines_land'," \
     "'ne_10m_admin_0_countries'," \
+    "'ne_10m_admin_0_boundary_lines_map_units'," \
     "'ne_10m_admin_1_states_provinces'," \
     "'ne_10m_admin_1_states_provinces_lines'," \
     "'ne_10m_antarctic_ice_shelves_polys'," \

--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -65,4 +65,3 @@ done
 echo "$count tables have been dropped from $NATURAL_EARTH_DB, vacuuming..."
 echo "VACUUM;" | sqlite3 "$NATURAL_EARTH_DB"
 echo "Done with $NATURAL_EARTH_DB -- final size $(du -h "$NATURAL_EARTH_DB" | cut -f1)"
-

--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -65,3 +65,4 @@ done
 echo "$count tables have been dropped from $NATURAL_EARTH_DB, vacuuming..."
 echo "VACUUM;" | sqlite3 "$NATURAL_EARTH_DB"
 echo "Done with $NATURAL_EARTH_DB -- final size $(du -h "$NATURAL_EARTH_DB" | cut -f1)"
+


### PR DESCRIPTION
Some low-zoom boundaries are missing from OpenMapTiles, most notably the Wales/Scotland boundaries in the UK. This proposes to add the missing Natural Earth table which contains the needed geometry:

![Missing boundary geometry](https://user-images.githubusercontent.com/3254090/211627237-5cc9654e-cffe-4a06-9f82-b75947627ab4.png)

See discussion at: https://osmus.slack.com/archives/C01V02K52UX/p1673281524155989

