### PR TITLE
Bump version mapnik-german-l10n

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -15,7 +15,7 @@ ARG UTF8PROC_TAG=v2.5.0
 ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
 # osml10n - https://github.com/openmaptiles/mapnik-german-l10n/releases
-ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9.1
+ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9.2
 ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/openmaptiles/mapnik-german-l10n.git
 
 


### PR DESCRIPTION
The new version of `mapnik-german-l10n` with fixed downloading of nomination `country_grid`.

Will fix the [GitHub Actions ](https://github.com/openmaptiles/openmaptiles-tools/actions/runs/3856812100/jobs/6641798992#step:5:1041).

Full release notes - https://github.com/openmaptiles/mapnik-german-l10n/releases/tag/v2.5.9.2