### PR TITLE
Add NE 10m urban areas

### DIFF
--- a/docker/import-data/clean-natural-earth.sh
+++ b/docker/import-data/clean-natural-earth.sh
@@ -43,6 +43,7 @@ for tbl in $(echo \
     "'ne_10m_lakes'," \
     "'ne_10m_ocean'," \
     "'ne_10m_populated_places'," \
+    "'ne_10m_urban_areas'," \
     "'ne_50m_admin_0_boundary_lines_land'," \
     "'ne_50m_antarctic_ice_shelves_polys'," \
     "'ne_50m_glaciated_areas'," \


### PR DESCRIPTION
In ZeLonewolf/openstreetmap-americana#617, we discovered that OpenMapTiles is using natural earth "urbanized areas" for residential landuse below zoom 6, and `landuse=residential` for zoom 6 and above. Since these are _wildly different things_, there is a noticeable discontinuity when zooming in past z6 as urban areas turn into residential landuse.  I propose to separate the two features into two separate classes in openmaptiles/openmaptiles#1454 as well as band-aid a fix for z6 by rendering it one additional zoom. However, there is still a need, as described in ZeLonewolf/openstreetmap-americana#617, to display urban areas at zooms closer than z6. This PR adds the 10m urbanized areas table from Natural Earth in order to support adding this functionality to OpenMapTiles.

> Looks good to me.  It would be nice to keep showing urbanized areas and/or more detailed landuse at medium to high zoom levels as well, but with the polygons in the source layer changing drastically after z6, that doesn't seem viable currently.
>
> **Zoom 5.99:**
> ![image](https://user-images.githubusercontent.com/281482/207490981-3d023ab8-4776-43f1-b36b-0500d247b439.png) 
>
> Zoom 6.00 (if the maxzoom were removed).  Hartford disappears, Boston shrinks, and a few random blotches show up in Maine...
> ![image](https://user-images.githubusercontent.com/281482/207491077-12fd7583-2a79-4f59-b6bf-1f53615640bc.png)
>
> _Originally posted by @zekefarwell in https://github.com/ZeLonewolf/openstreetmap-americana/pull/617#pullrequestreview-1216698007_
