### PR TITLE
Add LabelCenterline function

### DIFF
--- a/sql/LabelCenterline.sql
+++ b/sql/LabelCenterline.sql
@@ -1,0 +1,69 @@
+/******************************************************************************
+### LabelCenterline ###
+
+Given a polygon or multipolygon, calculates a linestring suitable for a label.
+
+__Parameters:__
+
+- `geometry` input - A polygon or multipolygon.
+
+__Returns:__ `geometry(linestring)`
+******************************************************************************/
+CREATE OR REPLACE FUNCTION CountDisconnectedEndpoints(polyline geometry, line geometry) RETURNS integer
+    AS 'SELECT ST_NPoints(ST_RemoveRepeatedPoints(ST_Points(polyline)))
+                    - ST_NPoints(ST_RemoveRepeatedPoints(ST_Points(ST_Difference(polyline, line))))
+                    - ST_NPoints(line) + 2;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+CREATE OR REPLACE FUNCTION TrimmedCenterline(polyline geometry) RETURNS geometry AS '
+    WITH tbla AS (
+        SELECT polyline, (ST_Dump(polyline)).geom as line
+    ),
+    tblb AS (
+        SELECT polyline, line as shortestBranchLine
+        FROM tbla
+        WHERE CountDisconnectedEndpoints(polyline, line) > 0
+        ORDER BY ST_Length(line) ASC
+        LIMIT 1
+    ),
+    tblc AS (
+        SELECT ST_LineMerge(ST_Difference(polyline, shortestBranchLine)) as polyline
+        FROM tblb
+    )
+    SELECT TrimmedCenterline(polyline) as polyline
+    FROM tblc
+    WHERE ST_NumGeometries(polyline) > 1
+    UNION ALL
+    SELECT polyline FROM tblc
+;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+CREATE OR REPLACE FUNCTION LabelCenterline(input geometry) RETURNS geometry AS '
+    WITH tbla AS (
+        SELECT input as polygon WHERE ST_GeometryType(input) = ''ST_Polygon''
+        UNION ALL
+        SELECT ST_ConcaveHull(input, 0.1) as polygon WHERE ST_GeometryType(input)=''ST_MultiPolygon''
+    ),
+    tblb AS (
+        SELECT ST_MakePolygon(ST_ExteriorRing(polygon)) as polygon
+        FROM tbla
+    ),
+    tblc AS (
+        SELECT polygon, (ST_Dump(ST_VoronoiLines(ST_LineInterpolatePoints(ST_Boundary(polygon), 0.0075)))).geom as lines
+        FROM tblb
+        WHERE ST_GeometryType(polygon) = ''ST_Polygon''
+    ),
+    tbld AS (
+        SELECT ST_LineMerge(ST_Collect(lines)) as polyline
+        FROM tblc
+        WHERE ST_Contains(polygon, lines)
+    )
+    SELECT ST_ChaikinSmoothing(ST_SimplifyPreserveTopology(TrimmedCenterline(polyline), 80), 3, false) FROM tbld
+;'
+    LANGUAGE SQL
+    IMMUTABLE
+    RETURNS NULL ON NULL INPUT;
+
+


### PR DESCRIPTION
Closes #354. The goal is to replace [acalcutt/osm-lakelines](https://github.com/acalcutt/osm-lakelines) with a faster SQL function. I've never written anything this complex in SQL before, so any help with efficiency and best practices is appreciated. I'm also new to this project, so I'm not sure about where to hook this in.

The logic:
1. Get the exterior polygon (ignoring islands) and use a convex hull if for some reason there's more than one exterior polygon
2. Use ST_LineInterpolatePoints to evenly distribute vertices around the polygon
3. Get ST_VoronoiLines from the interpolated vertices and covert to edges
4. Filter to only edges within the polygon
5. Recursively clip the shortest branch edges until only a single line is left
6. Simplify, smooth, and return

SFCGAL is not required for this method.

It takes about 40 seconds to calculate lines for the 395 largest lakes of Michigan, which I think is already a big improvement over osm-lakelines. The recursion takes about 75% of this time and can probably be made vastly more efficient.

The results are relatively consistent with osm-lakelines and I think look pretty good, except when there are large islands or bays.

<img width="532" alt="Screenshot 2023-02-27 at 9 47 15 PM" src="https://user-images.githubusercontent.com/2046746/221743328-1751e35f-528c-4945-9e7d-b62be4accf5b.png">
<img width="471" alt="Screenshot 2023-02-27 at 9 47 01 PM" src="https://user-images.githubusercontent.com/2046746/221743333-963bc32c-a2f1-4440-8262-66a0b3bbd138.png">
<img width="690" alt="Screenshot 2023-02-27 at 9 45 37 PM" src="https://user-images.githubusercontent.com/2046746/221743335-dda19e78-a0ce-4c56-af0f-19f584b31cee.png">
