### PR TITLE
Upgrade MAPNIK_GERMAN_L10N_TAG.

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -15,7 +15,7 @@ ARG UTF8PROC_TAG=v2.5.0
 ARG UTF8PROC_REPO=https://github.com/JuliaLang/utf8proc.git
 
 # osml10n - https://github.com/openmaptiles/mapnik-german-l10n/releases
-ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9.2
+ARG MAPNIK_GERMAN_L10N_TAG=v2.5.9.3
 ARG MAPNIK_GERMAN_L10N_REPO=https://github.com/openmaptiles/mapnik-german-l10n.git
 
 


### PR DESCRIPTION
This PR upgrades `MAPNIK_GERMAN_L10_TAG`  for https://github.com/openmaptiles/mapnik-german-l10n.git repo
The new release of the mapnik-german repo contains a forgotten bugfix for kakasi library.