### PR TITLE
Fix npm in openmaptiles-tools Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,6 @@ RUN set -eux ;\
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
         nodejs npm build-essential ;\
     rm -rf /var/lib/apt/lists/  ;\
-    npm config set unsafe-perm true  ;\
     npm install -g \
       @mapbox/mbtiles@0.12.1 \
       @mapbox/tilelive@6.1.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN set -eux ;\
     curl -sL https://deb.nodesource.com/setup_14.x | bash -  ;\
     DEBIAN_FRONTEND=noninteractive apt-get update  ;\
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
-        nodejs build-essential ;\
+        nodejs npm build-essential ;\
     rm -rf /var/lib/apt/lists/  ;\
     npm config set unsafe-perm true  ;\
     npm install -g \


### PR DESCRIPTION
When running `make build-docker`, getting this error:
```
 /bin/sh: 1: npm: not found
------
process "/bin/sh -c set -eux ;    /bin/bash -c 'echo \"\"; echo \"\"; echo \"##### Installing packages...\"' >&2 ;    DEBIAN_FRONTEND=noninteractive apt-get update ;    DEBIAN_FRONTEND=noninteractive apt-get install  -y --no-install-recommends         ca-certificates         curl         wget         git          less         nano         procps  `# ps command`         gnupg2  `# TODO: not sure why gnupg2 is needed`  ;    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ;    /bin/bash -c 'source /etc/os-release && echo \"deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME:?}-pgdg main ${PG_MAJOR:?}\" > /etc/apt/sources.list.d/pgdg.list' ;    DEBIAN_FRONTEND=noninteractive apt-get update ;    DEBIAN_FRONTEND=noninteractive apt-get install  -y --no-install-recommends         aria2     `# multi-stream file downloader - used by download-osm`         graphviz  `# used by layer mapping graphs`         sqlite3   `# mbtiles file manipulations`           gdal-bin  `# contains ogr2ogr`         osmctools `# osmconvert and other OSM tools`         osmosis   `# useful toolset - https://wiki.openstreetmap.org/wiki/Osmosis`         postgresql-client-${PG_MAJOR:?}  `# psql`                 libgeos-dev         libleveldb-dev         libprotobuf-dev         ;    curl -sL https://deb.nodesource.com/setup_14.x | bash -  ;    DEBIAN_FRONTEND=noninteractive apt-get update  ;    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends          nodejs build-essential ;    rm -rf /var/lib/apt/lists/  ;    npm config set unsafe-perm true  ;    npm install -g       @mapbox/mbtiles@0.12.1       @mapbox/tilelive@6.1.1       @beyondtracks/spritezero-cli@2.3.1       tilelive-pgquery@1.2.0 ;        /bin/bash -c 'echo \"\"; echo \"\"; echo \"##### Cleaning up\"' >&2 ;    rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 127
make: *** [Makefile:62: build-docker] Error 1
```
after adding `npm` package still getting error:
```
npm config set unsafe-perm true
npm ERR! `unsafe-perm` is not a valid npm option
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-06-28T13_02_20_674Z-debug-0.log
------
process "/bin/sh -c set -eux ;    /bin/bash -c 'echo \"\"; echo \"\"; echo \"##### Installing packages...\"' >&2 ;    DEBIAN_FRONTEND=noninteractive apt-get update ;    DEBIAN_FRONTEND=noninteractive apt-get install  -y --no-install-recommends         ca-certificates         curl         wget         git          less         nano         procps  `# ps command`         gnupg2  `# TODO: not sure why gnupg2 is needed`  ;    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ;    /bin/bash -c 'source /etc/os-release && echo \"deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME:?}-pgdg main ${PG_MAJOR:?}\" > /etc/apt/sources.list.d/pgdg.list' ;    DEBIAN_FRONTEND=noninteractive apt-get update ;    DEBIAN_FRONTEND=noninteractive apt-get install  -y --no-install-recommends         aria2     `# multi-stream file downloader - used by download-osm`         graphviz  `# used by layer mapping graphs`         sqlite3   `# mbtiles file manipulations`           gdal-bin  `# contains ogr2ogr`         osmctools `# osmconvert and other OSM tools`         osmosis   `# useful toolset - https://wiki.openstreetmap.org/wiki/Osmosis`         postgresql-client-${PG_MAJOR:?}  `# psql`                 libgeos-dev         libleveldb-dev         libprotobuf-dev         ;    curl -sL https://deb.nodesource.com/setup_14.x | bash -  ;    DEBIAN_FRONTEND=noninteractive apt-get update  ;    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends          nodejs npm build-essential ;    rm -rf /var/lib/apt/lists/  ;    npm config set unsafe-perm true  ;    npm install -g       @mapbox/mbtiles@0.12.1       @mapbox/tilelive@6.1.1       @beyondtracks/spritezero-cli@2.3.1       tilelive-pgquery@1.2.0 ;        /bin/bash -c 'echo \"\"; echo \"\"; echo \"##### Cleaning up\"' >&2 ;    rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 1
make: *** [Makefile:62: build-docker] Error 1
```

After the changes the Docker image is built and `make generate-tiles-pg` runs without an issue.