### PR TITLE
Add option to set tile extent to generate-sqltomvt

### DIFF
--- a/bin/generate-sqltomvt
+++ b/bin/generate-sqltomvt
@@ -8,7 +8,7 @@ Usage:
                     [--function | --prepared | --query | --psql | --raw]
                     [--layer=<layer>]... [--exclude-layers] [--key]
                     [--gzip [<gzlevel>]] [--no-feature-ids]
-                    [--test-geometry]
+                    [--test-geometry] [--extent=<extent>]
   generate-sqltomvt --help
   generate-sqltomvt --version
 
@@ -31,6 +31,7 @@ Options:
   --no-feature-ids      Disable feature ID generation, e.g. from osm_id.
                         You must use this flag when generating SQL for PostGIS before v3
   -g --test-geometry    Validate all geometries produced by ST_AsMvtGeom(), and warn.
+  --extent=<extent>     MVT tile extent [default: 4096].
   --help                Show this screen.
   --version             Show version.
 """
@@ -49,6 +50,8 @@ if __name__ == '__main__':
     else:
         zoom, x, y = 'zoom', 'x', 'y'
 
+    extent = int(args['--extent']) if args['--extent'] is not None else 4096
+
     mvt = MvtGenerator(
         tileset=args['<tileset>'],
         postgis_ver=args['--postgis-ver'],
@@ -59,6 +62,7 @@ if __name__ == '__main__':
         gzip=args['--gzip'] and (args['<gzlevel>'] or True),
         use_feature_id=False if args['--no-feature-ids'] else None,
         test_geometry=args['--test-geometry'],
+        extent=extent,
     )
 
     if args['--prepared']:


### PR DESCRIPTION
With default extent some curved lines can get wobbly:
![Screenshot from 2023-09-05 14-02-32](https://github.com/openmaptiles/openmaptiles-tools/assets/6237234/017f2e28-9f80-4f0a-bf48-a921a107c873)

Increasing extent can help mitigate it, but currently there is no easy way to this. This PR adds option to `generate-sqltomvt` so it's possible to override default tile extent.
